### PR TITLE
Build image in travis and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - docker-compose up -d
+
+script:
+  - ./test/test-musicbrainz-image.sh

--- a/musicbrainz-dockerfile/scripts/start.sh
+++ b/musicbrainz-dockerfile/scripts/start.sh
@@ -2,7 +2,7 @@
 
 env | grep '^DB_' | sed 's/^/export /' > /exports.txt
 
-./musicbrainz-server/script/compile_resources.sh
+./script/compile_resources.sh
 
 cron -f &
 redis-server --daemonize yes

--- a/test/test-musicbrainz-image.sh
+++ b/test/test-musicbrainz-image.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+sleep 2m
+
+HAS_SCRIPTS=$(curl 'http://localhost:5000/' | grep '/static/build/common' 2> /dev/null)
+
+if [[ -n $HAS_SCRIPTS ]]; then
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
This change adds some basic tests for the musicbrainz image
and closes #15. The test confirms that musicbrainz serves
a page and has built the static resources.
