### PR TITLE
Updating to postgres 9.5 for latest replication data

### DIFF
--- a/postgres-dockerfile/Dockerfile
+++ b/postgres-dockerfile/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:9.4
+FROM postgres:9.5
 MAINTAINER jeffsturgis@gmail.com
 
 # Update the Ubuntu and PostgreSQL repository indexes
 RUN apt-get update
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y -q install git-core build-essential libxml2-dev libpq-dev libexpat1-dev libdb-dev libicu-dev postgresql-server-dev-9.4
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y -q install git-core build-essential libxml2-dev libpq-dev libexpat1-dev libdb-dev libicu-dev postgresql-server-dev-9.5
 
 RUN git clone https://github.com/metabrainz/postgresql-musicbrainz-unaccent.git && git clone https://github.com/metabrainz/postgresql-musicbrainz-collate.git
 


### PR DESCRIPTION
Simply updating to postgres 9.5 for use with latest mbrainz replication data.

https://blog.musicbrainz.org/2016/05/25/schema-change-release-2016-05-23-with-upgrade-instructions/
