### PR TITLE
Improvements to postgres-dockerfile/Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ musicbrainz docker container
 
 [![Build Status](https://travis-ci.org/jsturgis/musicbrainz-docker.svg?branch=master)](https://travis-ci.org/jsturgis/musicbrainz-docker)
 
-* Current MB Branch: v-2016-05-23-schema-change-v2
-* Current DB_SCHEMA_SEQUENCE: 23
-* Postgres Version: 9.5
+* Current MB Branch: [v-2016-05-23-schema-change-v2](musicbrainz-dockerfile/Dockerfile#L22)
+* Current DB_SCHEMA_SEQUENCE: [23](musicbrainz-dockerfile/DBDefs.pm#L95)
+* Postgres Version: [9.5](postgres-dockerfile/Dockerfile#L1)
 
 This repo contains everything needed to run a musicbrainz slave server with replication in a docker container.
 You will need a little over 20 gigs of free space to run this with replication.

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@ musicbrainz docker container
 
 [![Build Status](https://travis-ci.org/jsturgis/musicbrainz-docker.svg?branch=master)](https://travis-ci.org/jsturgis/musicbrainz-docker)
 
+This repo contains everything needed to run a musicbrainz slave server with replication in a docker container.
+You will need a little over 20 gigs of free space to run this with replication.
+
+### Versions
 * Current MB Branch: [v-2016-05-23-schema-change-v2](musicbrainz-dockerfile/Dockerfile#L22)
 * Current DB_SCHEMA_SEQUENCE: [23](musicbrainz-dockerfile/DBDefs.pm#L95)
 * Postgres Version: [9.5](postgres-dockerfile/Dockerfile#L1)
-
-This repo contains everything needed to run a musicbrainz slave server with replication in a docker container.
-You will need a little over 20 gigs of free space to run this with replication.
 
 ### Configuration
 * Set the path where you want to store the downloaded data dumps in [docker-compose.yml](./docker-compose.yml).

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ musicbrainz docker container
 
 [![Build Status](https://travis-ci.org/jsturgis/musicbrainz-docker.svg?branch=master)](https://travis-ci.org/jsturgis/musicbrainz-docker)
 
-#### Current MB Branch: v-2016-05-23-schema-change-v2
-#### Current DB_SCHEMA_SEQUENCE: 23
-#### Postgres Version: 9.5
+* Current MB Branch: v-2016-05-23-schema-change-v2
+* Current DB_SCHEMA_SEQUENCE: 23
+* Postgres Version: 9.5
 
 This repo contains everything needed to run a musicbrainz slave server with replication in a docker container.
 You will need a little over 20 gigs of free space to run this with replication.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ musicbrainz docker container
 
 [![Build Status](https://travis-ci.org/jsturgis/musicbrainz-docker.svg?branch=master)](https://travis-ci.org/jsturgis/musicbrainz-docker)
 
+#### Current MB Branch: v-2016-05-23-schema-change-v2
+#### Current DB_SCHEMA_SEQUENCE: 23
+#### Postgres Version: 9.5
+
 This repo contains everything needed to run a musicbrainz slave server with replication in a docker container.
 You will need a little over 20 gigs of free space to run this with replication.
 

--- a/postgres-dockerfile/Dockerfile
+++ b/postgres-dockerfile/Dockerfile
@@ -1,10 +1,12 @@
 FROM postgres:9.5
 MAINTAINER jeffsturgis@gmail.com
 
+ARG DEBIAN_FRONTEND="noninteractive"
+
 # Update the Ubuntu and PostgreSQL repository indexes
 RUN apt-get update
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y -q install git-core build-essential libxml2-dev libpq-dev libexpat1-dev libdb-dev libicu-dev postgresql-server-dev-9.5
+RUN apt-get -y -q install git-core build-essential libxml2-dev libpq-dev libexpat1-dev libdb-dev libicu-dev postgresql-server-dev-9.5
 
 RUN git clone https://github.com/metabrainz/postgresql-musicbrainz-unaccent.git && git clone https://github.com/metabrainz/postgresql-musicbrainz-collate.git
 

--- a/postgres-dockerfile/Dockerfile
+++ b/postgres-dockerfile/Dockerfile
@@ -4,9 +4,17 @@ MAINTAINER jeffsturgis@gmail.com
 ARG DEBIAN_FRONTEND="noninteractive"
 
 # Update the Ubuntu and PostgreSQL repository indexes
-RUN apt-get update
+RUN apt-get update && \
+  apt-get -y -q install \
+    git-core \
+    build-essential \
+    libxml2-dev \
+    libpq-dev \
+    libexpat1-dev \
+    libdb-dev \
+    libicu-dev \
+    postgresql-server-dev-9.5
 
-RUN apt-get -y -q install git-core build-essential libxml2-dev libpq-dev libexpat1-dev libdb-dev libicu-dev postgresql-server-dev-9.5
 
 RUN git clone https://github.com/metabrainz/postgresql-musicbrainz-unaccent.git && git clone https://github.com/metabrainz/postgresql-musicbrainz-collate.git
 

--- a/postgres-dockerfile/Dockerfile
+++ b/postgres-dockerfile/Dockerfile
@@ -17,7 +17,11 @@ RUN apt-get update && \
 
 
 RUN git clone https://github.com/metabrainz/postgresql-musicbrainz-unaccent.git && git clone https://github.com/metabrainz/postgresql-musicbrainz-collate.git
+WORKDIR /postgresql-musicbrainz-unaccent
+RUN make && make install
+WORKDIR /postgresql-musicbrainz-collate
+RUN make && make install
+WORKDIR /
 
-RUN cd postgresql-musicbrainz-unaccent && make && make install && cd ../postgresql-musicbrainz-collate && make && make install && cd ../
 
 RUN echo "listen_addresses='*'" >> /var/lib/postgresql/data/postgresql.conf

--- a/postgres-dockerfile/Dockerfile
+++ b/postgres-dockerfile/Dockerfile
@@ -15,13 +15,15 @@ RUN apt-get update && \
     libicu-dev \
     postgresql-server-dev-9.5
 
+RUN git clone https://github.com/metabrainz/postgresql-musicbrainz-unaccent.git /tmp/postgresql-musicbrainz-unaccent && \
+  git clone https://github.com/metabrainz/postgresql-musicbrainz-collate.git /tmp/postgresql-musicbrainz-collate
 
-RUN git clone https://github.com/metabrainz/postgresql-musicbrainz-unaccent.git && git clone https://github.com/metabrainz/postgresql-musicbrainz-collate.git
-WORKDIR /postgresql-musicbrainz-unaccent
+WORKDIR /tmp/postgresql-musicbrainz-unaccent
 RUN make && make install
-WORKDIR /postgresql-musicbrainz-collate
+WORKDIR /tmp/postgresql-musicbrainz-collate
 RUN make && make install
 WORKDIR /
 
+RUN rm -R /tmp/*
 
 RUN echo "listen_addresses='*'" >> /var/lib/postgresql/data/postgresql.conf


### PR DESCRIPTION
This PR resolves #24, by addressing the two issues highlighted there. It merged the `apt-get update` and `apt-get install` RUN commands into a single RUN command, and switches to using WORKDIR instead of `cd ... && ...`

It additionally makes the use of `DEBIAN_FRONTEND="noninteractive"` clearer, and checks out the MB postgres extensions to the /tmp/ folder, and deletes them following installation, to reduce image size.
