### PR TITLE
It is illegal to drop the current database, ensure postgres DB is used.

### DIFF
--- a/musicbrainz-dockerfile/scripts/recreatedb.sh
+++ b/musicbrainz-dockerfile/scripts/recreatedb.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-psql -U $DB_ENV_POSTGRES_USER -h db -c "DROP DATABASE musicbrainz;" && /createdb.sh -fetch
+psql -U $DB_ENV_POSTGRES_USER -h db -c "DROP DATABASE musicbrainz;" postgres && /createdb.sh -fetch


### PR DESCRIPTION
Otherwise, script fails dropping musicbrainz DB as the default is to
connect to the DB with the same name as the connecting user.