### PR TITLE
Install explicit cpan packages into local::lib prefix

### DIFF
--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get install -y nodejs
 
 RUN cd /musicbrainz-server/ && eval $( perl -Mlocal::lib) && cpanm --installdeps --notest .
-RUN cpanm --notest Plack::Middleware::Debug::Base \
+RUN eval $( perl -Mlocal::lib) && cpanm --notest Plack::Middleware::Debug::Base \
     Catalyst::Plugin::Cache::HTTP \
     Catalyst::Plugin::StackTrace \
     Cache::Memcached::Fast \


### PR DESCRIPTION
If packages are not installed into the local::lib prefix, they will not be seen by the MusicBrainz code.

~~I don't believe that these explicit installations are actually required now that deps are adequately defined inside the MusicBrainz repo (the fact that they were not installed via local::lib suggests that they can not have been used by MB anyway, since that migration).  I think the only one that should remain is the DBD-Pg package, which currently requires version pinning due to Unicode bugs in DBD-Pg-3.6.0.  If you agree @jsturgis, please let me know and I will update the PR to remove the extraneous packages.~~

I see how the extra packages are used.

Refs #41