### PR TITLE
Use dumpdata path as temporary storage for createdb.sh

### DIFF
--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -4,10 +4,13 @@ eval $( perl -Mlocal::lib )
 
 FTP_HOST=ftp://ftp.musicbrainz.org
 FETCH_DUMPS=$1
+TMP_DIR=/media/dbdump/tmp
 
 if [[ $2 != "" ]]; then
     FTP_HOST=$2
 fi
+
+mkdir $TMP_DIR || true
 
 if [[ $FETCH_DUMPS == "-fetch" ]]; then
   echo "fetching data dumps"
@@ -18,11 +21,12 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
   LATEST=$(cat /media/dbdump/LATEST)
   wget -r --no-parent -nd -nH -P /media/dbdump --reject "index.html*, mbdump-edit*, mbdump-documentation*" "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST"
   pushd /media/dbdump && md5sum -c MD5SUMS && popd
-  /musicbrainz-server/admin/InitDb.pl --createdb --import /media/dbdump/mbdump*.tar.bz2 --echo
-elif [[ -a /media/dbdump/mbdump.tar.bz2 ]]; then
+fi
+
+if [[ -a /media/dbdump/mbdump.tar.bz2 ]]; then
   echo "found existing dumps"
 
-  /musicbrainz-server/admin/InitDb.pl --createdb --import /media/dbdump/mbdump*.tar.bz2 --echo
+  /musicbrainz-server/admin/InitDb.pl --createdb --import /media/dbdump/mbdump*.tar.bz2 --tmp-dir $TMP_DIR --echo
 else
   echo "no dumps found or dumps are incomplete"
   /musicbrainz-server/admin/InitDb.pl --createdb --echo


### PR DESCRIPTION
This avoids a scenario where there is not enough storage at the docker
container storage location to store the unpacked dumpdata, by colocating
the unpacked data with the original dumps.