### PR TITLE
Redis container and dockerize

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,15 +21,12 @@ services:
       - ./postgres-dockerfile/postgres.env
     environment:
       - MUSICBRAINZ_USE_PROXY=1
-    expose:
-      - "5000"
     depends_on:
       - db
       - search
 
   indexer:
     build: indexer-dockerfile
-    restart: unless-stopped
     depends_on:
       - db
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   db:
     build: postgres-dockerfile
-    restart: always
+    restart: unless-stopped
     env_file:
       - ./postgres-dockerfile/postgres.env
     volumes:
@@ -16,7 +16,7 @@ services:
       - "5000:5000"
     volumes:
       - /datadump:/media/dbdump
-    restart: always
+    restart: unless-stopped
     env_file:
       - ./postgres-dockerfile/postgres.env
     environment:
@@ -29,6 +29,7 @@ services:
 
   indexer:
     build: indexer-dockerfile
+    restart: unless-stopped
     depends_on:
       - db
     volumes:
@@ -36,7 +37,7 @@ services:
 
   search:
     build: search-dockerfile
-    restart: always
+    restart: unless-stopped
     expose:
       - "8080"
     volumes:
@@ -45,10 +46,6 @@ services:
 
   redis:
     image: redis:3.2.1
+    restart: unless-stopped
     expose:
       - "6379"
-
-  nginx:
-    image: nginx:1.13.3
-    expose:
-      - "80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,3 +42,13 @@ services:
     volumes:
       - /mnt/data:/home/search/data
       - /mnt/data:/home/search/indexdata
+
+  redis:
+    image: redis:3.2.1
+    expose:
+      - "6379"
+
+  nginx:
+    image: nginx:1.13.3
+    expose:
+      - "80"

--- a/musicbrainz-dockerfile/DBDefs.pm
+++ b/musicbrainz-dockerfile/DBDefs.pm
@@ -295,7 +295,7 @@ sub DATASTORE_REDIS_ARGS {
     return {
         database => 0,
         namespace => 'MB:',
-        server => '127.0.0.1:6379',
+        server => 'redis:6379',
         test_database => 1,
     };
 }

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -1,6 +1,10 @@
 FROM metabrainz/base-image
 MAINTAINER Jeff Sturgis <jeffsturgis@gmail.com>
 
+ENV DOCKERIZE_VERSION v0.2.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 RUN apt-get update && \
     apt-get install -y \
     git-core \
@@ -63,4 +67,6 @@ RUN crontab /crons.conf
 
 VOLUME  ["/media/dbdump"]
 WORKDIR /musicbrainz-server
-CMD ["/start.sh"]
+CMD dockerize -wait tcp://db:5432 -timeout 60s \
+    -wait tcp://redis:6379 -timeout 60s \
+    /start.sh

--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -32,7 +32,7 @@ fi
 if [[ -a /media/dbdump/mbdump.tar.bz2 ]]; then
   echo "found existing dumps"
 
-  /musicbrainz-server/admin/InitDb.pl --createdb --import /media/dbdump/mbdump*.tar.bz2 --tmp-dir $TMP_DIR --echo
+  /musicbrainz-server/admin/InitDb.pl --import /media/dbdump/mbdump*.tar.bz2 --tmp-dir $TMP_DIR --echo
 else
   echo "no dumps found or dumps are incomplete"
   /musicbrainz-server/admin/InitDb.pl --createdb --echo

--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -17,8 +17,11 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
 
   apt-get install -y wget
   rm -rf /media/dbdump/*
+  echo "Get LATEST file"
   wget -nd -nH -P /media/dbdump $FTP_HOST/pub/musicbrainz/data/fullexport/LATEST
   LATEST=$(cat /media/dbdump/LATEST)
+  echo "latest -$LATEST-"
+  echo "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST"
   wget -r --no-parent -nd -nH -P /media/dbdump --reject "index.html*, mbdump-edit*, mbdump-documentation*" "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST"
   pushd /media/dbdump && md5sum -c MD5SUMS && popd
 fi

--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -17,12 +17,15 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
 
   apt-get install -y wget
   rm -rf /media/dbdump/*
-  echo "Get LATEST file"
   wget -nd -nH -P /media/dbdump $FTP_HOST/pub/musicbrainz/data/fullexport/LATEST
   LATEST=$(cat /media/dbdump/LATEST)
-  echo "latest -$LATEST-"
-  echo "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST"
-  wget -r --no-parent -nd -nH -P /media/dbdump --reject "index.html*, mbdump-edit*, mbdump-documentation*" "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST"
+  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/MD5SUMS"
+  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump.tar.bz2"
+  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-cdstubs.tar.bz2"
+  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-cover-art-archive.tar.bz2"
+  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-derived.tar.bz2"
+  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-stats.tar.bz2"
+  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-wikidocs.tar.bz2"
   pushd /media/dbdump && md5sum -c MD5SUMS && popd
 fi
 

--- a/musicbrainz-dockerfile/scripts/start.sh
+++ b/musicbrainz-dockerfile/scripts/start.sh
@@ -5,7 +5,5 @@ eval $( perl -Mlocal::lib )
 env | grep '^DB_' | sed 's/^/export /' > /exports.txt
 
 cron -f &
-redis-server --daemonize yes
-nginx
 /start_mb_renderer.pl
 start_server --port=55901 -- plackup -I lib -s Starlet -E deployment --nproc 10 --pid fcgi.pid

--- a/musicbrainz-dockerfile/scripts/start.sh
+++ b/musicbrainz-dockerfile/scripts/start.sh
@@ -5,5 +5,6 @@ eval $( perl -Mlocal::lib )
 env | grep '^DB_' | sed 's/^/export /' > /exports.txt
 
 cron -f &
+nginx
 /start_mb_renderer.pl
 start_server --port=55901 -- plackup -I lib -s Starlet -E deployment --nproc 10 --pid fcgi.pid


### PR DESCRIPTION
This PR uses a redis image and add dockerize support to wait for redis and postgres to start before attempting to start the musicbrainz-server. This should fix the problem of containers not starting correctly in musicbrainz-vm.