### PR TITLE
fix the createdb and recreatedb scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ To view the replication log file you can run this command
 ### If you need to recreate the database
 you will need to enter the postgres password that you set in [postgres.env](postgres-dockerfile/postgres.env).
 * `sudo docker-compose run --rm musicbrainz /recreatedb.sh`
+or to recreate and fetch new data dumps
+* `sudo docker-compose run --rm musicbrainz /recreatedb.sh -fetch`
 
 ### Handling Schema Updates
 When there is a schema change you will need to follow the directions posted by the musicbrainz team to update the schema.

--- a/indexer-dockerfile/Dockerfile
+++ b/indexer-dockerfile/Dockerfile
@@ -1,6 +1,6 @@
 FROM airdock/oracle-jdk:jdk-8u74
 
-MAINTAINER Robert Kaye <rob@metabrainz.org>
+LABEL Author="Robert Kaye <rob@metabrainz.org>"
 
 WORKDIR /home/search
 RUN curl -o /home/search/index.jar ftp://ftp.eu.metabrainz.org/pub/musicbrainz/search/index/index.jar

--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -31,7 +31,11 @@ if [[ -a /media/dbdump/mbdump.tar.bz2 ]]; then
   echo "found existing dumps"
 
   mkdir -p $TMP_DIR
-  /musicbrainz-server/admin/InitDb.pl --createdb --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2
+
+  # if the import fails because the DB does not exist yet such as when the DB
+  # has been dropped, InitDb will be called again with the create flag
+  /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2 ||
+  /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2
 else
   echo "no dumps found or dumps are incomplete"
 fi

--- a/musicbrainz-dockerfile/scripts/recreatedb.sh
+++ b/musicbrainz-dockerfile/scripts/recreatedb.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+eval $( perl -Mlocal::lib )
 
-psql -U musicbrainz -h db -c "DROP DATABASE musicbrainz;" postgres && /createdb.sh -fetch
+FETCH_DUMPS=$1
+
+psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz;"; /createdb.sh $FETCH_DUMPS

--- a/postgres-dockerfile/Dockerfile
+++ b/postgres-dockerfile/Dockerfile
@@ -1,5 +1,5 @@
 FROM postgres:9.5
-MAINTAINER jeffsturgis@gmail.com
+LABEL Author="jeffsturgis@gmail.com"
 
 ARG DEBIAN_FRONTEND="noninteractive"
 

--- a/search-dockerfile/Dockerfile
+++ b/search-dockerfile/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9.3.10
 
-MAINTAINER Robert Kaye <rob@metabrainz.org>
+LABEL Author="Robert Kaye <rob@metabrainz.org>"
 
 WORKDIR $JETTY_HOME
 RUN curl -o $JETTY_HOME/webapps/ROOT.war http://ftp.eu.metabrainz.org/pub/musicbrainz/search/servlet/searchserver.war


### PR DESCRIPTION
This change fixes an issue where if the DB is already created then createdb.sh will fail.
I also fixed an issue with the recreatedb script where it would fail if anyone was still
connected to the musicbrainz DB.