### PR TITLE
Add .gitattributes to preserve EOLs in .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Shell scripts
+*.sh eol=lf
+*.conf eof=lf
+*.pl eol=lf
+*.pm eol=lf
+configure eol=lf
+configure.ac eol=lf


### PR DESCRIPTION
This PR prevents Windows clients from converting the LF EOL in .sh, .conf, .pl, and .pm files to CRLF.

Previously, Windows clients would convert EOLs to CRLF, then the containers would fail to start and have errors because these files were ADDed to the Linux container with Windows-style line endings.