### PR TITLE
Upgrade to the latest MusicBrainz Server v-2018-05-30

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains everything needed to run a musicbrainz slave server with sear
 You will need a little over 50 gigs of free space to run this with replication.
 
 ### Versions
-* Current MB Branch: [v-2018-01-24](musicbrainz-dockerfile/Dockerfile#L24)
+* Current MB Branch: [v-2018-06-30](musicbrainz-dockerfile/Dockerfile#L24)
 * Current DB_SCHEMA_SEQUENCE: [24](musicbrainz-dockerfile/DBDefs.pm#L107)
 * Postgres Version: [9.5](postgres-dockerfile/Dockerfile#L1)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains everything needed to run a musicbrainz slave server with sear
 You will need a little over 50 gigs of free space to run this with replication.
 
 ### Versions
-* Current MB Branch: [v-2018-01-24](musicbrainz-dockerfile/Dockerfile#L23)
+* Current MB Branch: [v-2018-01-24](musicbrainz-dockerfile/Dockerfile#L24)
 * Current DB_SCHEMA_SEQUENCE: [24](musicbrainz-dockerfile/DBDefs.pm#L107)
 * Postgres Version: [9.5](postgres-dockerfile/Dockerfile#L1)
 

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
 
 RUN git clone --recursive https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server && \
     cd musicbrainz-server && \
-    git checkout v-2018-01-24
+    git checkout v-2018-06-30
 
 RUN cd tmp && \
     curl -sLO https://deb.nodesource.com/node_8.x/pool/main/n/nodejs/nodejs_8.11.3-1nodesource1_amd64.deb && \

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -16,14 +16,16 @@ RUN apt-get update && \
     libdb-dev \
     libicu-dev \
     liblocal-lib-perl \
+    python-minimal \
     cpanminus
 
 RUN git clone --recursive https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server && \
     cd musicbrainz-server && \
     git checkout v-2018-01-24
 
-RUN curl -sLO https://deb.nodesource.com/node_7.x/pool/main/n/nodejs/nodejs_7.9.0-1nodesource1~xenial1_amd64.deb && \
-    dpkg -i nodejs_7.9.0-1nodesource1~xenial1_amd64.deb
+RUN cd tmp && \
+    curl -sLO https://deb.nodesource.com/node_8.x/pool/main/n/nodejs/nodejs_8.11.3-1nodesource1_amd64.deb && \
+    dpkg -i nodejs_8.11.3-1nodesource1_amd64.deb
 
 RUN cd /musicbrainz-server/ && eval $( perl -Mlocal::lib) && cpanm --installdeps --notest .
 RUN eval $( perl -Mlocal::lib) && cpanm --notest Plack::Middleware::Debug::Base \

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -23,9 +23,16 @@ RUN git clone --recursive https://github.com/metabrainz/musicbrainz-server.git m
     cd musicbrainz-server && \
     git checkout v-2018-06-30
 
-RUN cd tmp && \
+RUN cd musicbrainz-server && \
+    cp docker/yarn_pubkey.txt /tmp && \
+    cd /tmp && \
+    apt-key add yarn_pubkey.txt && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update -o Dir::Etc::sourcelist="sources.list.d/yarn.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
     curl -sLO https://deb.nodesource.com/node_8.x/pool/main/n/nodejs/nodejs_8.11.3-1nodesource1_amd64.deb && \
-    dpkg -i nodejs_8.11.3-1nodesource1_amd64.deb
+    dpkg -i nodejs_8.11.3-1nodesource1_amd64.deb && \
+    apt remove -y cmdtest && \
+    apt-get install -y yarn
 
 RUN cd /musicbrainz-server/ && eval $( perl -Mlocal::lib) && cpanm --installdeps --notest .
 RUN eval $( perl -Mlocal::lib) && cpanm --notest Plack::Middleware::Debug::Base \
@@ -52,7 +59,7 @@ ADD scripts/createdb.sh /createdb.sh
 ADD scripts/recreatedb.sh /recreatedb.sh
 ADD scripts/set-token.sh /set-token.sh
 
-RUN cd /musicbrainz-server/ && npm install --only=production \
+RUN cd /musicbrainz-server/ && yarn install --production \
     && eval $( perl -Mlocal::lib) && /musicbrainz-server/script/compile_resources.sh
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Note: MBS uses yarn instead of npm since v-2018-04-23.

Node.js 7.9.0 was not supported anymore and [was potentially flawed](https://nodejs.org/en/blog/vulnerability/june-2018-security-releases/).
Node.js is upgraded to its latest LTS release: 8.11.3.