### PR TITLE
Use new musicbrainz config values for search server

### DIFF
--- a/musicbrainz-dockerfile/DBDefs.pm
+++ b/musicbrainz-dockerfile/DBDefs.pm
@@ -158,7 +158,8 @@ sub REPLICATION_ACCESS_TOKEN { "" }
 sub WEB_SERVER                { "localhost:5000" }
 # Relevant only if SSL redirects are enabled
 # sub WEB_SERVER_SSL            { "localhost" }
-sub LUCENE_SERVER             { "search:8080" }
+sub SEARCH_SERVER             { "search:8080" }
+sub SEARCH_ENGINE             { "LUCENE" }
 # Used, for example, to have emails sent from the beta server list the
 # main server
 # sub WEB_SERVER_USED_IN_EMAIL  { my $self = shift; $self->WEB_SERVER }

--- a/postgres-dockerfile/postgres.env
+++ b/postgres-dockerfile/postgres.env
@@ -1,5 +1,2 @@
 POSTGRES_USER=musicbrainz
 POSTGRES_PASSWORD=musicbrainz
-
-PGUSER=musicbrainz
-PGPASSWORD=musicbrainz

--- a/postgres-dockerfile/postgres.env
+++ b/postgres-dockerfile/postgres.env
@@ -1,2 +1,5 @@
 POSTGRES_USER=musicbrainz
 POSTGRES_PASSWORD=musicbrainz
+
+PGUSER=musicbrainz
+PGPASSWORD=musicbrainz


### PR DESCRIPTION
As seen here in the tagged v-2018-01-24 build of the musicbrainz-server there are new settings to specify your downstream search service.
https://github.com/metabrainz/musicbrainz-server/blob/v-2018-01-24/lib/DBDefs/Default.pm#L105

This PR updates the relevant settings in the DBDefs.pm file.

If not specified, search requests are proxied to search.musicbrainz.org.