### PR TITLE
Upgrade Redis version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - indexdata:/home/search/indexdata
 
   redis:
-    image: redis:3.2.1
+    image: redis:3
     restart: unless-stopped
     expose:
       - "6379"


### PR DESCRIPTION
Redis version `3.2.1` fail.

```
Pulling redis (redis:3.2.1)...
3.2.1: Pulling from library/redis
5c90d4a2d1a8: Already exists
8e636c10fc4b: Extracting [==================================================>]  2.037kB/2.037kB
a4486ffc4334: Download complete
66471c0ab8a7: Download complete
b8697f5c1d8a: Download complete
c771d8e60b99: Download complete
ebd65895367f: Download complete
ERROR: failed to register layer: open /mnt/4tb/docker/images/aufs/layers/7706f913e0c7ca32ad49088bde0ba7b388505b402bc09b8b1058db587a69b47d: no such file or directory
```