### PR TITLE
Provide an option to expose the postgres and redis ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ You will need a little over 50 gigs of free space to run this with replication.
 
 ###### Install and Start
 * Make sure you have installed docker and docker-compose then:
-* `git clone this-repo`
-* `cd this-repo`
+* `git clone https://github.com/metabrainz/musicbrainz-docker.git`
+* `cd musicbrainz-docker`
 * `sudo docker-compose up -d`
+* or to expose the db and redis ports: `sudo docker-compose -f docker-compose.yml -f docker-compose.public.yml up -d`
 * Set the token you got from musicbrainz (instructions for generating a token are [here](http://blog.musicbrainz.org/2015/05/19/schema-change-release-2015-05-18-including-upgrade-instructions/)).
 * `sudo docker exec musicbrainzdocker_musicbrainz_1 /set-token.sh <replication token>`
 

--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  db:
+    ports:
+      - "5432:5432"
+  redis:
+    ports:
+      - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 volumes:
   pgdata:


### PR DESCRIPTION
This change is to allow someone to run musicbrainz with the
db port open to internet traffic.