### PR TITLE
Use slimmer Redis image based on Alpine Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - indexdata:/home/search/indexdata
 
   redis:
-    image: redis:3
+    image: redis:3-alpine
     restart: unless-stopped
     expose:
       - "6379"


### PR DESCRIPTION
As suggested in https://github.com/metabrainz/musicbrainz-docker/pull/73#issuecomment-403206051, this patch uses [`redis:alpine`](https://hub.docker.com/_/redis/) which is already used for musicbrainz.org since one year ago.