### PR TITLE
Upgrade to dockerize v0.5.0

### DIFF
--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -1,7 +1,7 @@
 FROM metabrainz/base-image
 LABEL maintainer=jeffsturgis@gmail.com
 
-ENV DOCKERIZE_VERSION v0.2.0
+ENV DOCKERIZE_VERSION v0.5.0
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz


### PR DESCRIPTION
This includes a fix for a bug that displays `waiting on dependencies to become available`, in loop, in some case/setup.