### PR TITLE
Update code of conduct (pointing to MeB CoC)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,14 +1,9 @@
-MusicBrainz Code of Conduct
-===========================
+MetaBrainz Code of Conduct
+==========================
 
-This project follows the **[MusicBrainz Code of
-Conduct](https://musicbrainz.org/doc/Code_of_Conduct "Code of Conduct -
-MusicBrainz")**. The _Community members_ section applies to this and all other
-MetaBrainz-sponsored projects.
+This project follows the **[MetaBrainz code of conduct
+](https://metabrainz.org/code-of-conduct
+"Code of Conduct - MetaBrainz Foundation")**.
 
-The full MusicBrainz Code of Conduct is found here:
-
-    https://musicbrainz.org/doc/Code_of_Conduct
-
-For questions about the Code of Conduct or to get help, please email
-support@metabrainz.org.
+For questions about the code of conduct or to get help, please email
+support@metabrainz.org or post on https://community.metabrainz.org/


### PR DESCRIPTION
MusicBrainz code of conduct has been generalized into MetaBrainz code of conduct, in [March 2018](https://community.metabrainz.org/t/updating-our-code-of-conduct-privacy-policy-and-social-contract/366652). Now, [MusicBrainz code of conduct](https://musicbrainz.org/doc/Code_of_Conduct) is specific to database editing, while [MetaBrainz code of conduct](https://metabrainz.org/code-of-conduct) applies to every other project.

This patch updates the file `CODE_OF_CONDUCT.md` to point to MetaBrainz code of conduct.