### PR TITLE
Upgrade to MusicBrainz Server v-2018-08-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains everything needed to run a musicbrainz slave server with sear
 You will need a little over 50 gigs of free space to run this with replication.
 
 ### Versions
-* Current MB Branch: [v-2018-06-30](musicbrainz-dockerfile/Dockerfile#L26)
+* Current MB Branch: [v-2018-08-14](musicbrainz-dockerfile/Dockerfile#L26)
 * Current DB_SCHEMA_SEQUENCE: [24](musicbrainz-dockerfile/DBDefs.pm#L107)
 * Postgres Version: [9.5](postgres-dockerfile/Dockerfile#L1)
 

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 
 RUN git clone --recursive https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server && \
     cd musicbrainz-server && \
-    git checkout v-2018-06-30
+    git checkout v-2018-08-14
 
 RUN cd musicbrainz-server && \
     cp docker/yarn_pubkey.txt /tmp && \


### PR DESCRIPTION
**Note:** As for `v-2018-06-30`, a “squash and merge” of pull request https://github.com/metabrainz/musicbrainz-docker/pull/72 is still required.