### PR TITLE
Import editor dump

### DIFF
--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -24,6 +24,7 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
   wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-derived.tar.bz2"
   wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-stats.tar.bz2"
   wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-wikidocs.tar.bz2"
+  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-editor.tar.bz2"
   pushd /media/dbdump && md5sum -c MD5SUMS && popd
 fi
 
@@ -34,8 +35,8 @@ if [[ -a /media/dbdump/mbdump.tar.bz2 ]]; then
 
   # if the import fails because the DB does not exist yet such as when the DB
   # has been dropped, InitDb will be called again with the create flag
-  /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2 ||
-  /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2
+  /musicbrainz-server/admin/InitDb.pl --echo --import -- --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2 ||
+  /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2
 else
   echo "no dumps found or dumps are incomplete"
 fi


### PR DESCRIPTION
The web interface no longer renders most entities unless editor data is
available, and the data is not very large, so this change just
re-enables the import.