### PR TITLE
Allow setting Postgres version via build-time argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ You will need a little over 50 gigs of free space to run this with replication.
 ### Versions
 * Current MB Branch: [v-2019-01-22](musicbrainz-dockerfile/Dockerfile#L30)
 * Current DB_SCHEMA_SEQUENCE: [24](musicbrainz-dockerfile/DBDefs.pm#L107)
-* Postgres Version: [9.5](postgres-dockerfile/Dockerfile#L1)
+* Postgres Version: [9.5](postgres-dockerfile/docker-compose.yml)
+  (can be changed by setting the environement variable `POSTGRES_VERSION`)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains everything needed to run a musicbrainz slave server with sear
 You will need a little over 50 gigs of free space to run this with replication.
 
 ### Versions
-* Current MB Branch: [v-2019-01-22](musicbrainz-dockerfile/Dockerfile#L26)
+* Current MB Branch: [v-2019-01-22](musicbrainz-dockerfile/Dockerfile#L30)
 * Current DB_SCHEMA_SEQUENCE: [24](musicbrainz-dockerfile/DBDefs.pm#L107)
 * Postgres Version: [9.5](postgres-dockerfile/Dockerfile#L1)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     build:
       context: postgres-dockerfile
       args:
-        - POSTGRES_VERSION=9.5
-    image: musicbrainz-docker_db:9.5
+        - POSTGRES_VERSION=${POSTGRES_VERSION:-9.5}
+    image: musicbrainz-docker_db:${POSTGRES_VERSION:-9.5}
     restart: unless-stopped
     env_file:
       - ./postgres-dockerfile/postgres.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
       - "5432"
 
   musicbrainz:
-    build: musicbrainz-dockerfile
+    build:
+      context: musicbrainz-dockerfile
+      args:
+        - POSTGRES_VERSION=${POSTGRES_VERSION:-9.5}
     ports:
       - "5000:5000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,11 @@ volumes:
 
 services:
   db:
-    build: postgres-dockerfile
+    build:
+      context: postgres-dockerfile
+      args:
+        - POSTGRES_VERSION=9.5
+    image: musicbrainz-docker_db:9.5
     restart: unless-stopped
     env_file:
       - ./postgres-dockerfile/postgres.env

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -6,7 +6,10 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN apt-get update && \
+ARG POSTGRES_VERSION=9.5
+RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
     apt-get install -y \
         cpanminus \
         build-essential \
@@ -19,7 +22,7 @@ RUN apt-get update && \
         libpq-dev \
         libxml2-dev \
         memcached \
-        postgresql \
+        postgresql-${POSTGRES_VERSION} \
         python-minimal
 
 RUN git clone https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server && \

--- a/postgres-dockerfile/Dockerfile
+++ b/postgres-dockerfile/Dockerfile
@@ -1,7 +1,10 @@
-FROM postgres:9.5
+ARG POSTGRES_VERSION=9.5
+FROM postgres:${POSTGRES_VERSION}
 LABEL Author="jeffsturgis@gmail.com"
 
 ARG DEBIAN_FRONTEND="noninteractive"
+# Has to be redeclared due to being in a different build stage
+ARG POSTGRES_VERSION
 
 # Update the Ubuntu and PostgreSQL repository indexes
 RUN apt-get update && \
@@ -13,7 +16,7 @@ RUN apt-get update && \
         libicu-dev \
         libpq-dev \
         libxml2-dev \
-        postgresql-server-dev-9.5
+        postgresql-server-dev-${POSTGRES_VERSION}
 
 RUN git clone https://github.com/metabrainz/postgresql-musicbrainz-unaccent.git /tmp/postgresql-musicbrainz-unaccent && \
     git clone https://github.com/metabrainz/postgresql-musicbrainz-collate.git /tmp/postgresql-musicbrainz-collate


### PR DESCRIPTION
This PR allows setting the postgres version in it's dockerfile by using the `POSTGRES_VERSION` build-time argument (note `PG_VERSION` would collide with env vars of the parent image). The default is set to 9.5 as to not break workflows of users using the image directly.

It also makes use of the arg in the compose file where the version can easily be changed. Using the `image` option is necessary to force rebuilds on arg changes and makes switching between versions easier.

While this setup is very backwards-compatible, updating the postgres version would require changing it in all three places (although changing the Dockerfile is not strictly required). A build script or .env file could further optimize this.