### PR TITLE
Allow creating database from sample data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Create the database, and populate the database with existing dumps
 
 * `sudo docker-compose run --rm musicbrainz /createdb.sh`
 
+For development, to load sample data instead of full dump, use the flag `-sample`
+
 ### Build search indexes
 In order to use the search functions of the web site/API you will need to build search indexes.
 

--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -11,31 +11,31 @@ if [[ $2 != "" ]]; then
 fi
 
 if [[ $FETCH_DUMPS == "-fetch" ]]; then
-  echo "fetching data dumps"
+    echo "fetching data dumps"
 
-  apt-get install -y wget
-  rm -rf /media/dbdump/*
-  wget -nd -nH -P /media/dbdump $FTP_MB/data/fullexport/LATEST
-  LATEST=$(cat /media/dbdump/LATEST)
-  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/MD5SUMS"
-  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump.tar.bz2"
-  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-cdstubs.tar.bz2"
-  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-cover-art-archive.tar.bz2"
-  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-derived.tar.bz2"
-  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-stats.tar.bz2"
-  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-wikidocs.tar.bz2"
-  pushd /media/dbdump && md5sum -c MD5SUMS && popd
+    apt-get install -y wget
+    rm -rf /media/dbdump/*
+    wget -nd -nH -P /media/dbdump $FTP_MB/data/fullexport/LATEST
+    LATEST=$(cat /media/dbdump/LATEST)
+    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/MD5SUMS"
+    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump.tar.bz2"
+    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-cdstubs.tar.bz2"
+    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-cover-art-archive.tar.bz2"
+    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-derived.tar.bz2"
+    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-stats.tar.bz2"
+    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-wikidocs.tar.bz2"
+    pushd /media/dbdump && md5sum -c MD5SUMS && popd
 fi
 
 if [[ -a /media/dbdump/mbdump.tar.bz2 ]]; then
-  echo "found existing dumps"
+    echo "found existing dumps"
 
-  mkdir -p $TMP_DIR
+    mkdir -p $TMP_DIR
 
-  # if the import fails because the DB does not exist yet such as when the DB
-  # has been dropped, InitDb will be called again with the create flag
-  /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2 ||
-  /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2
+    # if the import fails because the DB does not exist yet such as when the DB
+    # has been dropped, InitDb will be called again with the create flag
+    /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2 ||
+    /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2
 else
-  echo "no dumps found or dumps are incomplete"
+    echo "no dumps found or dumps are incomplete"
 fi

--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -3,39 +3,92 @@
 eval $( perl -Mlocal::lib )
 
 FTP_MB=ftp://ftp.eu.metabrainz.org/pub/musicbrainz
-FETCH_DUMPS=$1
+IMPORT="fullexport"
+FETCH_DUMPS=""
+
+read -d '' -r HELP <<HELP
+Usage: $0 [-sample] [-fetch] [MUSICBRAINZ_FTP_URL]
+
+Options:
+  -fetch      Fetch latest dump from MusicBrainz FTP
+  -sample     Load sample data instead of full data
+
+Default MusicBrainz FTP URL: $FTP_MB
+HELP
+
+if [ $# -gt 3 ]; then
+    echo "$0: too many arguments"
+    echo "$HELP"
+    exit 1
+fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -sample )
+            IMPORT="sample"
+            ;;
+        -fetch  )
+            FETCH_DUMPS="$1"
+            ;;
+        -*      )
+            echo "$0: unrecognized option '$1'"
+            echo "$HELP"
+            exit 1
+            ;;
+        *       )
+            FTP_MB="$1"
+            ;;
+    esac
+    shift
+done
+
 TMP_DIR=/media/dbdump/tmp
 
-if [[ $2 != "" ]]; then
-    FTP_HOST=$2
-fi
+case "$IMPORT" in
+    fullexport  )
+        DUMP_FILES=(
+        mbdump.tar.bz2
+        mbdump-cdstubs.tar.bz2
+        mbdump-cover-art-archive.tar.bz2
+        mbdump-derived.tar.bz2
+        mbdump-stats.tar.bz2
+        mbdump-wikidocs.tar.bz2
+        );;
+    sample      )
+        DUMP_FILES=(
+        mbdump-sample.tar.xz
+        );;
+esac
 
 if [[ $FETCH_DUMPS == "-fetch" ]]; then
     echo "fetching data dumps"
 
     apt-get install -y wget
     rm -rf /media/dbdump/*
-    wget -nd -nH -P /media/dbdump $FTP_MB/data/fullexport/LATEST
+    wget -nd -nH -P /media/dbdump $FTP_MB/data/$IMPORT/LATEST
     LATEST=$(cat /media/dbdump/LATEST)
-    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/MD5SUMS"
-    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump.tar.bz2"
-    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-cdstubs.tar.bz2"
-    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-cover-art-archive.tar.bz2"
-    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-derived.tar.bz2"
-    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-stats.tar.bz2"
-    wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-wikidocs.tar.bz2"
-    pushd /media/dbdump && md5sum -c MD5SUMS && popd
+    if [[ $IMPORT == "fullexport" ]]; then
+        for F in MD5SUMS ${DUMP_FILES[@]}; do
+            wget -P /media/dbdump "$FTP_MB/data/$IMPORT/$LATEST/$F"
+        done
+        pushd /media/dbdump && md5sum -c MD5SUMS && popd
+    elif [[ $IMPORT == "sample" ]]; then
+        for F in ${DUMP_FILES[@]}; do
+            wget -P /media/dbdump "$FTP_MB/data/$IMPORT/$LATEST/$F"
+        done
+    fi
 fi
 
-if [[ -a /media/dbdump/mbdump.tar.bz2 ]]; then
+if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
     echo "found existing dumps"
 
     mkdir -p $TMP_DIR
+    cd /media/dbdump
 
     # if the import fails because the DB does not exist yet such as when the DB
     # has been dropped, InitDb will be called again with the create flag
-    /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2 ||
-    /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR /media/dbdump/mbdump*.tar.bz2
+    /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]} ||
+    /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
 else
     echo "no dumps found or dumps are incomplete"
 fi

--- a/musicbrainz-dockerfile/scripts/createdb.sh
+++ b/musicbrainz-dockerfile/scripts/createdb.sh
@@ -2,7 +2,7 @@
 
 eval $( perl -Mlocal::lib )
 
-FTP_HOST=ftp://ftp.eu.metabrainz.org
+FTP_MB=ftp://ftp.eu.metabrainz.org/pub/musicbrainz
 FETCH_DUMPS=$1
 TMP_DIR=/media/dbdump/tmp
 
@@ -15,15 +15,15 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
 
   apt-get install -y wget
   rm -rf /media/dbdump/*
-  wget -nd -nH -P /media/dbdump $FTP_HOST/pub/musicbrainz/data/fullexport/LATEST
+  wget -nd -nH -P /media/dbdump $FTP_MB/data/fullexport/LATEST
   LATEST=$(cat /media/dbdump/LATEST)
-  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/MD5SUMS"
-  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump.tar.bz2"
-  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-cdstubs.tar.bz2"
-  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-cover-art-archive.tar.bz2"
-  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-derived.tar.bz2"
-  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-stats.tar.bz2"
-  wget -P /media/dbdump "$FTP_HOST/pub/musicbrainz/data/fullexport/$LATEST/mbdump-wikidocs.tar.bz2"
+  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/MD5SUMS"
+  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump.tar.bz2"
+  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-cdstubs.tar.bz2"
+  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-cover-art-archive.tar.bz2"
+  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-derived.tar.bz2"
+  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-stats.tar.bz2"
+  wget -P /media/dbdump "$FTP_MB/data/fullexport/$LATEST/mbdump-wikidocs.tar.bz2"
   pushd /media/dbdump && md5sum -c MD5SUMS && popd
 fi
 

--- a/musicbrainz-dockerfile/scripts/recreatedb.sh
+++ b/musicbrainz-dockerfile/scripts/recreatedb.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 eval $( perl -Mlocal::lib )
 
-FETCH_DUMPS=$1
-
-psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; /createdb.sh $FETCH_DUMPS
+psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; /createdb.sh "$@"


### PR DESCRIPTION
Allow creating database from sample data for development purpose, just by adding `-sample` flag to either `createdb.sh` or `recreatedb.sh` command.

Plus, fix fetching (full or sample) data from Dotsrc.org mirror.