### PR TITLE
Upgrade to MusicBrainz Server v-2019-01-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains everything needed to run a musicbrainz slave server with sear
 You will need a little over 50 gigs of free space to run this with replication.
 
 ### Versions
-* Current MB Branch: [v-2018-08-14](musicbrainz-dockerfile/Dockerfile#L26)
+* Current MB Branch: [v-2019-01-22](musicbrainz-dockerfile/Dockerfile#L26)
 * Current DB_SCHEMA_SEQUENCE: [24](musicbrainz-dockerfile/DBDefs.pm#L107)
 * Postgres Version: [9.5](postgres-dockerfile/Dockerfile#L1)
 

--- a/musicbrainz-dockerfile/DBDefs.pm
+++ b/musicbrainz-dockerfile/DBDefs.pm
@@ -393,7 +393,7 @@ sub DEVELOPMENT_SERVER { 0 }
 # Please activate the officially approved languages here. Not every .po
 # file is active because we might have fully translated languages which
 # are not yet properly supported, like right-to-left languages
-# sub MB_LANGUAGES {qw()}
+sub MB_LANGUAGES { qw( de fr nl en ) }
 
 # Should the site fall back to browser settings when trying to set a language
 # (note: will still only use languages in MB_LANGUAGES)

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     apt-get install -y \
         cpanminus \
         build-essential \
+        gettext \
         git-core \
         libdb-dev \
         libexpat1-dev \

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 
 RUN git clone --recursive https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server && \
     cd musicbrainz-server && \
-    git checkout v-2018-08-14
+    git checkout v-2019-01-22
 
 RUN cd musicbrainz-server && \
     cp docker/yarn_pubkey.txt /tmp && \

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
         postgresql \
         python-minimal
 
-RUN git clone --recursive https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server && \
+RUN git clone https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server && \
     cd musicbrainz-server && \
     git checkout v-2019-01-22
 


### PR DESCRIPTION
Additionally:
- skip cloning unused submodules of `musicbrainz-server` for `musicbrainz` service;
- activate every language available in `po/`.