### PR TITLE
Upgrade to schema 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repo contains everything needed to run a musicbrainz slave server with sear
 You will need a little over 50 gigs of free space to run this with replication.
 
 ### Versions
-* Current MB Branch: [v-2019-01-22](musicbrainz-dockerfile/Dockerfile#L30)
-* Current DB_SCHEMA_SEQUENCE: [24](musicbrainz-dockerfile/DBDefs.pm#L107)
+* Current MB Branch: [v-2019-05-13-schema-change](musicbrainz-dockerfile/Dockerfile#L30)
+* Current DB_SCHEMA_SEQUENCE: [25](musicbrainz-dockerfile/DBDefs.pm#L107)
 * Postgres Version: [9.5](docker-compose.yml)
   (can be changed by setting the environement variable `POSTGRES_VERSION`)
 

--- a/musicbrainz-dockerfile/DBDefs.pm
+++ b/musicbrainz-dockerfile/DBDefs.pm
@@ -109,7 +109,7 @@ MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
 # replication_control.current_schema_sequence.
 # This is required, there is no default in order to prevent it changing without
 # manual intervention.
-sub DB_SCHEMA_SEQUENCE { 24 }
+sub DB_SCHEMA_SEQUENCE { 25 }
 
 # What type of server is this?
 # * RT_MASTER - This is a master replication server.  Changes are allowed, and

--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN git clone https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server && \
     cd musicbrainz-server && \
-    git checkout v-2019-01-22
+    git checkout v-2019-05-13-schema-change
 
 RUN cd musicbrainz-server && \
     cp docker/yarn_pubkey.txt /tmp && \


### PR DESCRIPTION
When running `createdb.sh` I was receiving the following error:
```
Schema sequence mismatch - codebase is 24, mbdump.tar.bz2 is 25
```

I'm not sure if there are any other changes needed, but updating the musicbrainz-server git tag and `DB_SCHEMA_SEQUENCE` fixed the issue for me.