### PR TITLE
Split test and development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repo contains everything needed to run a musicbrainz slave server with sear
   * [Local changes](#local-changes)
   * [Docker environment variables](#docker-environment-variables)
   * [Docker Compose overrides](#docker-compose-overrides)
-- [Development setup](#development-setup)
+- [Test setup](#test-setup)
 - [Helper scripts](#helper-scripts)
   * [Recreate database](#recreate-database)
 - [Update (after v1.0.0)](#update-after-v100)
@@ -287,16 +287,18 @@ admin/configure add publishing-all-ports
 sudo docker-compose up -d
 ```
 
-## Development setup
+## Test setup
 
-Run the below commands instead of following the regular [installation](#installation):
+If you just need a small server with sample data to test your own SQL
+queries and/or MusicBrainz Web Service calls, you can run the below
+commands instead of following the above [installation](#installation):
 
 ```bash
 git clone --branch mbvm-38-dev https://github.com/metabrainz/musicbrainz-docker.git
 cd musicbrainz-docker
 sudo docker-compose build
 sudo docker-compose run --rm musicbrainz /createdb.sh -sample -fetch
-admin/configure add musicbrainz-development
+admin/configure add musicbrainz-standalone
 sudo docker-compose up -d
 ```
 
@@ -307,7 +309,7 @@ The two differences are:
 [Build search indexes](#build-search-indexes) and
 [Enable live indexing](#enable-live-indexing) are the same.
 
-Replication is not applicable to development setup.
+Replication is not applicable to test setup.
 
 ## Helper scripts
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repo contains everything needed to run a musicbrainz slave server with sear
   * [Docker environment variables](#docker-environment-variables)
   * [Docker Compose overrides](#docker-compose-overrides)
 - [Test setup](#test-setup)
+- [Development setup](#development-setup)
 - [Helper scripts](#helper-scripts)
   * [Recreate database](#recreate-database)
 - [Update (after v1.0.0)](#update-after-v100)
@@ -296,9 +297,9 @@ commands instead of following the above [installation](#installation):
 ```bash
 git clone --branch mbvm-38-dev https://github.com/metabrainz/musicbrainz-docker.git
 cd musicbrainz-docker
+admin/configure add musicbrainz-standalone
 sudo docker-compose build
 sudo docker-compose run --rm musicbrainz /createdb.sh -sample -fetch
-admin/configure add musicbrainz-standalone
 sudo docker-compose up -d
 ```
 
@@ -310,6 +311,39 @@ The two differences are:
 [Enable live indexing](#enable-live-indexing) are the same.
 
 Replication is not applicable to test setup.
+
+## Development setup
+
+For local development of MusicBrainz Server, you can run the below
+commands instead of following the above [installation](#installation):
+
+```bash
+git clone --recursive https://github.com/metabrainz/musicbrainz-server.git
+MUSICBRAINZ_SERVER_LOCAL_ROOT=$PWD/musicbrainz-server
+git clone --branch mbvm-38-dev https://github.com/metabrainz/musicbrainz-docker.git
+cd musicbrainz-docker
+echo MUSICBRAINZ_SERVER_LOCAL_ROOT="$MUSICBRAINZ_SERVER_LOCAL_ROOT" >> .env
+admin/configure add musicbrainz-dev
+sudo docker-compose up -d
+sudo docker-compose run --rm musicbrainz /createdb.sh -sample -fetch
+```
+
+The four differences are:
+1. sample data dump is downloaded instead of full data dumps,
+2. MusicBrainz Server runs in standalone mode instead of slave mode,
+3. development mode is enabled (Catalyst debug, ...),
+4. MusicBrainz Server code is in `musicbrainz-server/` directory.
+
+After changing code in `musicbrainz-server/`, it can be run as follows:
+
+```bash
+sudo docker-compose restart musicbrainz
+```
+
+[Build search indexes](#build-search-indexes) and
+[Enable live indexing](#enable-live-indexing) are the same.
+
+Replication is not applicable to development setup.
 
 ## Helper scripts
 

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ sudo docker-compose run --rm musicbrainz /createdb.sh -sample -fetch
 The four differences are:
 1. sample data dump is downloaded instead of full data dumps,
 2. MusicBrainz Server runs in standalone mode instead of slave mode,
-3. development mode is enabled (Catalyst debug, ...),
+3. development mode is enabled (but Catalyst debug),
 4. MusicBrainz Server code is in `musicbrainz-server/` directory.
 
 After changing code in `musicbrainz-server/`, it can be run as follows:

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -432,8 +432,7 @@ sub MB_LANGUAGES { shift->DEVELOPMENT_SERVER()
 # Configure which html validator should be used.  If you run tests
 # often, you should probably run a local copy of the validator.  See
 # http://about.validator.nu/#src for instructions.
-# sub HTML_VALIDATOR { 'http://validator.w3.org/nu/?out=json' }
-# local use example: sub HTML_VALIDATOR { 'http://localhost:8888?out=json' }
+sub HTML_VALIDATOR { 'http://validator:8888?out=json' }
 
 # Set to 1 if you're a developer and plan to run tests locally. Never
 # enable in production.

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -1,0 +1,459 @@
+#!/usr/bin/env perl
+
+use warnings;
+# vi: set ts=4 sw=4 :
+#____________________________________________________________________________
+#
+#   MusicBrainz -- the open internet music database
+#
+#   Copyright (C) 1998 Robert Kaye
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+#   $Id$
+#____________________________________________________________________________
+
+package DBDefs;
+use parent 'DBDefs::Default';
+use MusicBrainz::Server::Replication ':replication_type';
+use MusicBrainz::Server::DatabaseConnectionFactory;
+
+# Commented-out lines should generally have sane defaults; anything that's uncommented
+# probably needs personal attention.
+
+################################################################################
+# Directories
+################################################################################
+
+# The server root, i.e. the parent directory of admin, bin, lib, root, etc.
+# By default, this uses the path of lib/DBDefs/Default.pm, minus '/lib/DBDefs/Default.pm'
+sub MB_SERVER_ROOT    { "/musicbrainz-server" }
+# Where static files are located
+# sub STATIC_FILES_DIR { my $self= shift; $self->MB_SERVER_ROOT . '/root/static' }
+
+################################################################################
+# The Database
+################################################################################
+
+# Configuring databases here is required; there are no defaults.
+MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
+    # How to connect when we need read-write access to the database
+    READWRITE => {
+        database    => "musicbrainz_db",
+        username    => "$ENV{POSTGRES_USER}",
+        password    => "$ENV{POSTGRES_PASSWORD}",
+        host        => "db",
+        port        => "5432",
+    },
+    # How to connect to a test database
+    TEST => {
+        database    => "musicbrainz_test",
+        username    => "$ENV{POSTGRES_USER}",
+        password    => "$ENV{POSTGRES_PASSWORD}",
+        host        => "db",
+        port        => "5432",
+    },
+    # How to connect to a Selenium test database. This database is created
+    # (and dropped) automatically by t/selenium.js, and uses the TEST
+    # database above as a template.
+    SELENIUM => {
+        database    => 'musicbrainz_selenium',
+        schema      => 'musicbrainz',
+        username    => "$ENV{POSTGRES_USER}",
+        password    => "$ENV{POSTGRES_PASSWORD}",
+        host        => "db",
+        port        => "5432",
+    },
+    # How to connect for read-only access.  See "REPLICATION_TYPE" (below)
+    READONLY => {
+        database    => "musicbrainz_db",
+        username    => "$ENV{POSTGRES_USER}",
+        password    => "$ENV{POSTGRES_PASSWORD}",
+        host        => "db",
+        port        => "5432",
+    },
+    # How to connect for administrative access
+    SYSTEM    => {
+        database    => "template1",
+        username    => "$ENV{POSTGRES_USER}",
+        password    => "$ENV{POSTGRES_PASSWORD}",
+        host        => "db",
+        port        => "5432",
+    },
+    # How to connect when running maintenance scripts located under admin/.
+    # This defaults to READWRITE if left undefined, but should be configured if
+    # READWRITE points to a connection pooler that doesn't support session-based features.
+#   MAINTENANCE    => {
+#       database    => "musicbrainz_db",
+#       username    => "$ENV{POSTGRES_USER}",
+#       password    => "$ENV{POSTGRES_PASSWORD}",
+#       host        => "db",
+#       port        => "5432",
+#   },
+    # Fill out only if RAWDATA lives on a different host from the READWRITE server.
+    # RAWDATA_SYSTEM => undef,
+);
+
+# The schema sequence number.  Must match the value in
+# replication_control.current_schema_sequence.
+# This is required, there is no default in order to prevent it changing without
+# manual intervention.
+sub DB_SCHEMA_SEQUENCE { 25 }
+
+# What type of server is this?
+# * RT_MASTER - This is a master replication server.  Changes are allowed, and
+#               they result in replication packets being produced.
+# * RT_SLAVE  - This is a slave replication server.  After loading a snapshot
+#               produced by a master, the only changes allowed are those made
+#               by applying the next replication packet in turn.  If the slave
+#               server is not going to be used for development work, change
+#               DB_STAGING_SERVER to 0.
+#
+#               A READONLY database connection must be configured if you
+#               choose RT_SLAVE, as well as the usual READWRITE.
+# * RT_STANDALONE - This server neither generates nor uses replication
+#               packets.  Changes to the database are allowed.
+sub REPLICATION_TYPE { $ENV{MUSICBRAINZ_STANDALONE_SERVER} == 1
+    ? RT_STANDALONE
+    : RT_SLAVE
+}
+
+# If you plan to use the RT_SLAVE setting (replicated data from MusicBrainz' Live Data Feed)
+# you must sign in at https://metabrainz.org and generate an access token to access
+# the replication packets. Enter the access token below:
+# NOTE: DO NOT EXPOSE THIS ACCESS TOKEN PUBLICLY!
+#
+sub REPLICATION_ACCESS_TOKEN {
+    my $file = '/run/secrets/metabrainz_access_token';
+    open(my $fh, '<', $file) or return '';
+    read($fh, my $token, 40) or $token = '';
+    close $fh;
+    return $token;
+}
+
+################################################################################
+# GPG Signature
+################################################################################
+
+# Location of the public key file
+# sub GPG_PUB_KEY { "" }
+
+# Define how validation deals with the missing signature file:
+#   FAIL    - validation fails if signature file is missing
+#   PASS    - validation passes if signature file is missing
+# sub GPG_MISSING_SIGNATURE_MODE { "PASS" }
+
+# Key identifiers (compatible with --recipient in GPG) for
+# signatures and encryption of data dumps and packets. Should
+# only be required on the master server.
+# sub GPG_SIGN_KEY { "" }
+# sub GPG_ENCRYPT_KEY { "" }
+
+################################################################################
+# HTTP Server Names
+################################################################################
+
+# The host names used by the server.
+# To use a port number other than 80, add it like so: "myhost:8000"
+# Additionally you should set the environment variable
+# MUSICBRAINZ_USE_PROXY=1 when using a reverse proxy to make the server
+# aware of it when generating things like the canonical url in catalyst.
+sub WEB_SERVER                { "$ENV{MUSICBRAINZ_WEB_SERVER_HOST}:$ENV{MUSICBRAINZ_WEB_SERVER_PORT}" }
+# Relevant only if SSL redirects are enabled
+# sub WEB_SERVER_SSL            { "localhost" }
+sub SEARCH_SERVER             { "search:8983/solr" }
+sub SEARCH_ENGINE             { "SOLR" }
+# Used, for example, to have emails sent from the beta server list the
+# main server
+# sub WEB_SERVER_USED_IN_EMAIL  { my $self = shift; $self->WEB_SERVER }
+
+# Used for automatic beta redirection. Enabled if BETA_REDIRECT_HOSTNAME
+# is truthy.
+# sub IS_BETA                   { 0 }
+# sub BETA_REDIRECT_HOSTNAME    { '' }
+
+################################################################################
+# Mail Settings
+################################################################################
+
+# sub SMTP_SERVER { "localhost" }
+
+# This value should be set to some secret value for your server.  Any old
+# string of stuff should do; something suitably long and random, like for
+# passwords.  However you MUST change it from the default
+# value (the empty string).  This is so an attacker can't just look in CVS and
+# see the default secret value, and then use it to attack your server.
+
+# sub SMTP_SECRET_CHECKSUM { "" }
+# sub EMAIL_VERIFICATION_TIMEOUT { 604800 } # one week
+
+################################################################################
+# Server Settings
+################################################################################
+
+# Set this to 0 if this is the master MusicBrainz server or a slave mirror.
+# Keeping this defined enables the banner that is shown across the top of each
+# page, as well as some testing features that are only enabled when not on
+# the live server.
+sub DB_STAGING_SERVER { 0 }
+
+# This description is shown in the banner when DB_STAGING_SERVER is enabled.
+# If left empty the default value will be shown.
+# sub DB_STAGING_SERVER_DESCRIPTION { '' }
+
+# Only change this if running a non-sanitized database on a dev server,
+# e.g. http://test.musicbrainz.org.
+# sub DB_STAGING_SERVER_SANITIZED { 1 }
+
+# Testing features enable "Accept edit" and "Reject edit" links on edits,
+# this should only be enabled on staging servers. Also, this enables non-admin
+# users to edit user permissions.
+# sub DB_STAGING_TESTING_FEATURES { my $self = shift; $self->DB_STAGING_SERVER }
+
+# SSL_REDIRECTS_ENABLED should be set to 1 on production.  It enables
+# the "RequireSSL" attribute on Catalyst actions, which will redirect
+# users to the SSL version of a Catalyst action (and redirect back to
+# http:// after the action is complete, though only if the user
+# started there).  If set to 0 no SSL redirects will be done, which is
+# suitable for local or development deployments.
+# sub SSL_REDIRECTS_ENABLED { 0 }
+
+################################################################################
+# Documentation Server Settings
+################################################################################
+# sub WIKITRANS_SERVER     { "wiki.musicbrainz.org" }
+
+# The path to MediaWiki's api.php file. This is required to automatically
+# determine which documentation pages need to be updated in the
+# transclusion table.
+# sub WIKITRANS_SERVER_API { "wiki.musicbrainz.org/api.php" }
+
+# To enable documentation search on your server, create your own Google Custom
+# Search engine and enter its ID as the value of GOOGLE_CUSTOM_SEARCH.
+# Alternatively, if you're okay with the search results pointing to
+# the musicbrainz.org server, you can use '006539527923176875863:xsv3chs2ovc'.
+# sub GOOGLE_CUSTOM_SEARCH { '' }
+
+################################################################################
+# Cache Settings
+################################################################################
+
+# PLUGIN_CACHE_OPTIONS are the options configured for Plugin::Cache.  $c->cache
+# is provided by Plugin::Cache, and is required for HTTP Digest authentication
+# in the webservice (Catalyst::Authentication::Credential::HTTP).
+sub PLUGIN_CACHE_OPTIONS {
+    my $self = shift;
+    return {
+        class => 'MusicBrainz::Server::CacheWrapper::Redis',
+        server => 'redis:6379',
+        namespace => $self->CACHE_NAMESPACE . 'Catalyst:',
+    };
+}
+
+# The caching options here relate to object caching in Redis - such as for
+# artists, releases, etc. in order to speed up queries. See below if you want
+# to disable caching.
+sub CACHE_MANAGER_OPTIONS {
+    my $self = shift;
+    my %CACHE_MANAGER_OPTIONS = (
+        profiles => {
+            external => {
+                class => 'MusicBrainz::Server::CacheWrapper::Redis',
+                options => {
+                    server => 'redis:6379',
+                    namespace => $self->CACHE_NAMESPACE,
+                },
+            },
+        },
+        default_profile => 'external',
+    );
+
+    return \%CACHE_MANAGER_OPTIONS
+}
+
+# Sets the TTL for entities stored in Redis, in seconds. A value of 0
+# indicates that no expiration is set.
+sub ENTITY_CACHE_TTL { 3600 }
+
+################################################################################
+# Sessions (advanced)
+################################################################################
+
+# The session store holds user login sessions. Session::Store::MusicBrainz
+# uses DATASTORE_REDIS_ARGS to connect to and store sessions in Redis.
+
+# sub SESSION_STORE { "Session::Store::MusicBrainz" }
+# sub SESSION_STORE_ARGS { return {} }
+# sub SESSION_EXPIRE { return 36000; } # 10 hours
+
+# Redis by default has 16 numbered databases available, of which DB 0
+# is the default.  Here you can configure which of these databases are
+# used by musicbrainz-server.
+#
+# test_database will be completely erased on each test run, so make
+# sure it doesn't point at any production data you may have in your
+# redis server.
+
+sub DATASTORE_REDIS_ARGS {
+    my $self = shift;
+    return {
+        database => 0,
+        namespace => $self->CACHE_NAMESPACE,
+        server => 'redis:6379',
+        test_database => 1,
+    };
+}
+
+################################################################################
+# Session cookies
+################################################################################
+
+# How long (in seconds) a web/rdf session can go "idle" before being timed out
+# sub WEB_SESSION_SECONDS_TO_LIVE { 3600 * 3 }
+
+# The cookie name to use
+# sub SESSION_COOKIE { "AF_SID" }
+# The domain into which the session cookie is written
+# sub SESSION_DOMAIN { undef }
+
+################################################################################
+# Other Settings
+################################################################################
+
+# Set this value to something true (e.g. 1) to set the server to read-only.
+# To date, this option is widely ignored in the code; don't be surprised if you
+# set it to true and find that writes are still possible.
+# sub DB_READ_ONLY { 0 }
+
+# Set this value to a message that you'd like to display to users when
+# they attempt to write to your read-only database (not used if DB_READ_ONLY
+# is false)
+# sub DB_READ_ONLY_MESSAGE { <<EOF }
+# This server is temporarily in read-only mode
+# for database maintainance.
+# EOF
+
+# How long an annotation is considered as being locked.
+# sub ANNOTATION_LOCK_TIME { 60*15 }
+
+# Amazon associate and developer ids
+#my %amazon_store_associate_ids = (
+#    'amazon.ca'         => 'music0b72-20',
+#    'amazon.co.jp'    => 'musicbrainzjp-22',
+#    'amazon.co.uk'    => 'music080d-21',
+#    'amazon.com'    => 'musicbrainz0d-20',
+#    'amazon.de'         => 'music059-21',
+#    'amazon.fr'         => 'music083d-21',
+#    'amazon.it'         => 'music084d-21',
+#    'amazon.es'         => 'music02e-21',
+#);
+
+# sub AWS_ASSOCIATE_ID
+# {
+#     shift;
+#     return keys %amazon_store_associate_ids if not @_;
+#     return $amazon_store_associate_ids{$_[0]};
+# }
+
+# sub AWS_PRIVATE { '' }
+# sub AWS_PUBLIC { '' }
+
+# sub AMAZON_ASSOCIATE_TAG { '' }
+
+# To enable use of reCAPTCHA:
+# 1. make sure $ENV{'REMOTE_ADDR'} is the ip address of the visitor.
+# 2. replace undef with your recaptcha keys:
+# sub RECAPTCHA_PUBLIC_KEY { return undef }
+# sub RECAPTCHA_PRIVATE_KEY { return undef }
+
+# internet archive private/public keys (for coverartarchive.org).
+# sub COVER_ART_ARCHIVE_ACCESS_KEY { };
+# sub COVER_ART_ARCHIVE_SECRET_KEY { };
+# sub COVER_ART_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf("//%s.s3.us.archive.org/", shift) };
+# sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { "//coverartarchive.org" };
+
+# Disallow OAuth2 requests over plain HTTP
+# sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER }
+
+# sub USE_ETAGS { 1 }
+
+sub CATALYST_DEBUG { shift->DEVELOPMENT_SERVER() ? 1 : 0 }
+
+# If you are developing on MusicBrainz, you should set this to a true value
+# This will turn off some optimizations (such as CSS/JS compression) to make
+# developing and debuging easier
+sub DEVELOPMENT_SERVER { $ENV{MUSICBRAINZ_DEVELOPMENT_SERVER} == 1 ? 1 : 0 }
+
+# How long to wait before rechecking template files (undef uses the
+# Template::Toolkit default)
+# sub STAT_TTL { shift->DEVELOPMENT_SERVER() ? undef : 1200 }
+
+# Please activate the officially approved languages here. Not every .po
+# file is active because we might have fully translated languages which
+# are not yet properly supported, like right-to-left languages
+sub MB_LANGUAGES { shift->DEVELOPMENT_SERVER()
+    ? qw( de el es-es et fi fr it ja nl en )
+    : qw( de fr nl en )
+}
+
+# Should the site fall back to browser settings when trying to set a language
+# (note: will still only use languages in MB_LANGUAGES)
+# sub LANGUAGE_FALLBACK_TO_BROWSER{ 1 }
+
+# Bugs can be sent to a Sentry instance (https://sentry.io) via these settings.
+# The DSNs can be found on the project configuration page.
+# sub SENTRY_DSN { undef }
+# sub SENTRY_DSN_PUBLIC { undef }
+
+# Configure which html validator should be used.  If you run tests
+# often, you should probably run a local copy of the validator.  See
+# http://about.validator.nu/#src for instructions.
+# sub HTML_VALIDATOR { 'http://validator.w3.org/nu/?out=json' }
+# local use example: sub HTML_VALIDATOR { 'http://localhost:8888?out=json' }
+
+# Set to 1 if you're a developer and plan to run tests locally. Never
+# enable in production.
+# sub USE_SET_DATABASE_HEADER { 0 }
+
+# Disable auto forking it is handled by superdaemon
+sub FORK_RENDERER { 0 }
+
+################################################################################
+# Profiling
+################################################################################
+# Set these to >0 to enable profiling
+
+# Log if a request in /ws takes more than x seconds
+# sub PROFILE_WEB_SERVICE { 0 }
+
+# Log if a request in / (not /ws) takes more than x seconds
+# sub PROFILE_SITE { 0 }
+
+# The maximum amount of time a process can be serving a single request. This
+# function takes a Catalyst::Request as input, and should return the amount of time
+# in seconds that it should take to respond to this request.
+# If undef, the process is never killed.
+# sub DETERMINE_MAX_REQUEST_TIME { undef }
+
+# sub LOGGER_ARGUMENTS {
+#     return (
+#         outputs => [
+#             [ 'Screen', min_level => 'debug', newline => 1 ],
+#         ],
+#     )
+# }
+
+1;
+# eof DBDefs.pm

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -401,7 +401,7 @@ sub DATASTORE_REDIS_ARGS {
 
 # sub USE_ETAGS { 1 }
 
-sub CATALYST_DEBUG { shift->DEVELOPMENT_SERVER() ? 1 : 0 }
+sub CATALYST_DEBUG { $ENV{MUSICBRAINZ_CATALYST_DEBUG} == 0 ? 0 : 1 }
 
 # If you are developing on MusicBrainz, you should set this to a true value
 # This will turn off some optimizations (such as CSS/JS compression) to make

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -84,6 +84,18 @@ MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
         host        => "db",
         port        => "5432",
     },
+    # How to connect for read-only access to the production database in standby mode.
+    # This is for use by musicbrainz.org maintainers only, just ignore it otherwise.
+    # It can be used when an SSH tunnel is opened by running from Docker host:
+    #     ssh -L 172.17.0.1:65401:localhost:<PS_PORT> <PS_HOST> -N
+    # where <PS_PORT> and <PS_HOST_> are the production standby port and host, resp.
+    PROD_STANDBY => {
+        database    => "musicbrainz_db",
+        username    => "musicbrainz_ro",  # Standby is read-only anyway
+        password    => "",
+        host        => "172.17.0.1", # Gateway of Docker bridge network
+        port        => "65401",      # Port to be exposed by SSH tunnel
+    },
     # How to connect for administrative access
     SYSTEM    => {
         database    => "template1",

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -26,6 +26,16 @@ RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
         gettext \
         g++ \
         git \
+        language-pack-de \
+        language-pack-el \
+        language-pack-es \
+        language-pack-et \
+        language-pack-fi \
+        language-pack-fr \
+        language-pack-it \
+        language-pack-ja \
+        language-pack-nl \
+        language-pack-sq \
         # Needed for Cache in DB_File
         libdb-dev \
         libexpat1-dev \

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -68,8 +68,9 @@ RUN cat /snippet.perllocallib.bashrc >> ~/.bashrc \
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
 ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
 
-ENV MUSICBRAINZ_STANDALONE_SERVER=1 \
+ENV MUSICBRAINZ_CATALYST_DEBUG=0 \
     MUSICBRAINZ_DEVELOPMENT_SERVER=1 \
+    MUSICBRAINZ_STANDALONE_SERVER=1 \
     MUSICBRAINZ_WEB_SERVER_HOST=localhost \
     MUSICBRAINZ_WEB_SERVER_PORT=5000 \
     POSTGRES_USER=musicbrainz \

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -61,6 +61,8 @@ WORKDIR /musicbrainz-server
 
 COPY DBDefs.pm /
 COPY scripts/* /
+RUN cat /snippet.perllocallib.bashrc >> ~/.bashrc \
+    && rm /snippet.perllocallib.bashrc
 
 # Postgres user/password would be solely needed to compile tests
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -1,0 +1,66 @@
+FROM metabrainz/base-image
+LABEL maintainer="yvanzo@metabrainz.org"
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+ARG NODE_VERSION=10.19.0
+ARG POSTGRES_VERSION=9.5
+RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    apt-key adv --keyserver hkps.pool.sks-keyservers.net --refresh-keys Yarn && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install -y \
+        python-minimal && \
+    curl -sLO https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_${NODE_VERSION}-1nodesource1_amd64.deb && \
+    dpkg -i nodejs_${NODE_VERSION}-1nodesource1_amd64.deb && \
+    apt-get install -y \
+        cpanminus \
+        bash-completion \
+        build-essential \
+        bzip2 \
+        gettext \
+        g++ \
+        git \
+        # Needed for Cache in DB_File
+        libdb-dev \
+        libexpat1-dev \
+        libicu-dev \
+        liblocal-lib-perl \
+        libpq-dev \
+        libssl-dev \
+        # Needed for XML::LibXML
+        libxml2-dev \
+        make \
+        memcached \
+        # Needed for Unicode::ICU::Collator
+        pkg-config \
+        postgresql-${POSTGRES_VERSION} \
+        # Needed to decompress sample data
+        xz-utils \
+        yarn \
+        # Needed for XML:LibXML
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /musicbrainz-server
+
+COPY DBDefs.pm /
+COPY scripts/* /
+
+# Postgres user/password would be solely needed to compile tests
+ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
+ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
+
+ENV MUSICBRAINZ_STANDALONE_SERVER=1 \
+    MUSICBRAINZ_DEVELOPMENT_SERVER=1 \
+    MUSICBRAINZ_WEB_SERVER_HOST=localhost \
+    MUSICBRAINZ_WEB_SERVER_PORT=5000 \
+    POSTGRES_USER=musicbrainz \
+    POSTGRES_PASSWORD=musicbrainz
+
+CMD /start.sh

--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+eval $( perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}" )
+
+FTP_MB=ftp://ftp.eu.metabrainz.org/pub/musicbrainz
+IMPORT="fullexport"
+FETCH_DUMPS=""
+WGET_OPTIONS=""
+
+read -d '' -r HELP <<HELP
+Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_FTP_URL]
+
+Options:
+  -fetch      Fetch latest dump from MusicBrainz FTP
+  -sample     Load sample data instead of full data
+  -wget-opts  Pass additional space-separated options list (should be
+              a single argument, escape spaces if necessary) to wget
+
+Default MusicBrainz FTP URL: $FTP_MB
+HELP
+
+if [ $# -gt 4 ]; then
+    echo "$0: too many arguments"
+    echo "$HELP"
+    exit 1
+fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -wget-opts )
+            shift
+            WGET_OPTIONS=$1
+            ;;
+        -sample )
+            IMPORT="sample"
+            ;;
+        -fetch  )
+            FETCH_DUMPS="$1"
+            ;;
+        -*      )
+            echo "$0: unrecognized option '$1'"
+            echo "$HELP"
+            exit 1
+            ;;
+        *       )
+            FTP_MB="$1"
+            ;;
+    esac
+    shift
+done
+
+TMP_DIR=/media/dbdump/tmp
+
+case "$IMPORT" in
+    fullexport  )
+        DUMP_FILES=(
+        mbdump.tar.bz2
+        mbdump-cdstubs.tar.bz2
+        mbdump-cover-art-archive.tar.bz2
+        mbdump-derived.tar.bz2
+        mbdump-stats.tar.bz2
+        mbdump-wikidocs.tar.bz2
+        );;
+    sample      )
+        DUMP_FILES=(
+        mbdump-sample.tar.xz
+        );;
+esac
+
+if [[ $FETCH_DUMPS == "-fetch" ]]; then
+    echo "fetching data dumps"
+
+    rm -rf /media/dbdump/*
+    wget $WGET_OPTIONS -nd -nH -P /media/dbdump $FTP_MB/data/$IMPORT/LATEST
+    LATEST=$(cat /media/dbdump/LATEST)
+    if [[ $IMPORT == "fullexport" ]]; then
+        for F in MD5SUMS ${DUMP_FILES[@]}; do
+            wget $WGET_OPTIONS -P /media/dbdump "$FTP_MB/data/$IMPORT/$LATEST/$F"
+        done
+        pushd /media/dbdump && md5sum -c MD5SUMS && popd
+    elif [[ $IMPORT == "sample" ]]; then
+        for F in ${DUMP_FILES[@]}; do
+            wget $WGET_OPTIONS -P /media/dbdump "$FTP_MB/data/$IMPORT/$LATEST/$F"
+        done
+    fi
+fi
+
+if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
+    echo "found existing dumps"
+
+    mkdir -p $TMP_DIR
+    cd /media/dbdump
+
+    # if the import fails because the DB does not exist yet such as when the DB
+    # has been dropped, InitDb will be called again with the create flag
+    /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]} ||
+    /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
+else
+    echo "no dumps found or dumps are incomplete"
+fi

--- a/build/musicbrainz-dev/scripts/indexer-triggers.sh
+++ b/build/musicbrainz-dev/scripts/indexer-triggers.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+eval $( perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}" )
+
+set -e -u
+
+HELP="Usage: $0 INDEXER_SQL_DIR <create|drop>"
+
+if [ $# -ne 2 ]; then
+  echo "$0: wrong number of arguments"
+  echo "$HELP"
+  exit 1
+fi
+
+INDEXER_SQL_DIR="$1"
+
+cd /musicbrainz-server
+
+case "$2" in
+  create)
+    admin/psql < "$INDEXER_SQL_DIR/CreateFunctions.sql"
+    admin/psql < "$INDEXER_SQL_DIR/CreateTriggers.sql"
+    admin/GenerateSQLScripts.pl "$INDEXER_SQL_DIR/"
+    ;;
+  drop  )
+    admin/psql < "$INDEXER_SQL_DIR/DropTriggers.sql"
+    admin/psql < "$INDEXER_SQL_DIR/DropFunctions.sql"
+    rm -frv "$INDEXER_SQL_DIR"
+    ;;
+  *    )
+    echo "$0: unrecognized command '$2'"
+    echo "$HELP"
+    exit 1
+    ;;
+esac

--- a/build/musicbrainz-dev/scripts/recreatedb.sh
+++ b/build/musicbrainz-dev/scripts/recreatedb.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+eval $( perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}" )
+
+psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; /createdb.sh "$@"

--- a/build/musicbrainz-dev/scripts/replication.sh
+++ b/build/musicbrainz-dev/scripts/replication.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+eval $( perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}" )
+export POSTGRES_USER=${POSTGRES_USER:-musicbrainz}
+export POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-musicbrainz}
+
+/bin/bash /musicbrainz-server/admin/cron/slave.sh

--- a/build/musicbrainz-dev/scripts/snippet.perllocallib.bashrc
+++ b/build/musicbrainz-dev/scripts/snippet.perllocallib.bashrc
@@ -1,0 +1,5 @@
+
+# Enable locally installed Perl modules for interactive shell
+if [[ $- = *i* ]]; then
+    eval $( perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}" )
+fi

--- a/build/musicbrainz-dev/scripts/start.sh
+++ b/build/musicbrainz-dev/scripts/start.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+# liblocal-lib-perl < 2.000019 generates commands using unset variable
+eval $( perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}" )
+
+set -u
+
+mkdir -p "${MUSICBRAINZ_PERL_LOCAL_LIB}"
+mkdir -p "${PERL_CPANM_HOME}"
+
+cd /musicbrainz-server
+
+diff /DBDefs.pm lib/DBDefs.pm || cat /DBDefs.pm > lib/DBDefs.pm
+
+cpanm --installdeps --notest --with-develop .
+cpanm --notest \
+  Cache::Memcached::Fast \
+  Cache::Memory \
+  Catalyst::Plugin::Cache::HTTP \
+  Catalyst::Plugin::StackTrace \
+  Digest::MD5::File \
+  File::Slurp \
+  JSON::Any \
+  LWP::Protocol::https \
+  Plack::Handler::Starlet \
+  Plack::Middleware::Debug::Base \
+  Server::Starter \
+  Starlet \
+  Starlet::Server \
+  Term::Size::Any
+
+dockerize -wait tcp://db:5432 -timeout 60s -wait tcp://mq:5672 -timeout 60s -wait tcp://redis:6379 -timeout 60s ./script/compile_resources.sh
+
+/start_mb_renderer.pl
+start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --nproc 1 --pid fcgi.pid

--- a/build/musicbrainz-dev/scripts/start_mb_renderer.pl
+++ b/build/musicbrainz-dev/scripts/start_mb_renderer.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/musicbrainz-server/lib";
+use DBDefs;
+
+my $socket = DBDefs->RENDERER_SOCKET;
+
+system("rm $socket");
+system("/musicbrainz-server/script/start_renderer.pl --daemonize --socket $socket");

--- a/build/musicbrainz/DBDefs.pm
+++ b/build/musicbrainz/DBDefs.pm
@@ -124,7 +124,10 @@ sub DB_SCHEMA_SEQUENCE { 25 }
 #               choose RT_SLAVE, as well as the usual READWRITE.
 # * RT_STANDALONE - This server neither generates nor uses replication
 #               packets.  Changes to the database are allowed.
-sub REPLICATION_TYPE { shift->DEVELOPMENT_SERVER() ? RT_STANDALONE : RT_SLAVE }
+sub REPLICATION_TYPE { $ENV{MUSICBRAINZ_STANDALONE_SERVER} == 1
+    ? RT_STANDALONE
+    : RT_SLAVE
+}
 
 # If you plan to use the RT_SLAVE setting (replicated data from MusicBrainz' Live Data Feed)
 # you must sign in at https://metabrainz.org and generate an access token to access
@@ -390,7 +393,7 @@ sub CATALYST_DEBUG { shift->DEVELOPMENT_SERVER() ? 1 : 0 }
 # If you are developing on MusicBrainz, you should set this to a true value
 # This will turn off some optimizations (such as CSS/JS compression) to make
 # developing and debuging easier
-sub DEVELOPMENT_SERVER { $ENV{DEVELOPMENT_MUSICBRAINZ_DOCKER} == 1 ? 1 : 0 }
+sub DEVELOPMENT_SERVER { $ENV{MUSICBRAINZ_DEVELOPMENT_SERVER} == 1 ? 1 : 0 }
 
 # How long to wait before rechecking template files (undef uses the
 # Template::Toolkit default)

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -82,7 +82,7 @@ COPY scripts/* /
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
 ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
 
-ENV DEVELOPMENT_MUSICBRAINZ_DOCKER=0 \
+ENV MUSICBRAINZ_STANDALONE_SERVER=0 \
     MUSICBRAINZ_WEB_SERVER_HOST=localhost \
     MUSICBRAINZ_WEB_SERVER_PORT=5000 \
     POSTGRES_USER=musicbrainz \

--- a/compose/musicbrainz-dev.yml
+++ b/compose/musicbrainz-dev.yml
@@ -13,3 +13,10 @@ services:
       - MUSICBRAINZ_DEVELOPMENT_SERVER=${MUSICBRAINZ_DEVELOPMENT_SERVER:-1}
       - PERL_CPANM_HOME=${MUSICBRAINZ_PERL_CPANM_HOME:-/musicbrainz-server/.cpanm}
       - MUSICBRAINZ_PERL_LOCAL_LIB=${MUSICBRAINZ_PERL_LOCAL_LIB:-/musicbrainz-server/perl_modules}
+    depends_on:
+      - validator
+  validator:
+    image: validator/validator:20.3.16
+    restart: unless-stopped
+    expose:
+      - "8888"

--- a/compose/musicbrainz-dev.yml
+++ b/compose/musicbrainz-dev.yml
@@ -1,0 +1,13 @@
+version: '3.1'
+
+# Description: Build and run local development copy of MusicBrainz Server
+
+services:
+  musicbrainz:
+    build:
+      context: build/musicbrainz-dev
+    volumes:
+      - ${MUSICBRAINZ_SERVER_LOCAL_ROOT:?Missing path of musicbrainz-server working copy}:/musicbrainz-server
+    environment:
+      - PERL_CPANM_HOME=${MUSICBRAINZ_PERL_CPANM_HOME:-/musicbrainz-server/.cpanm}
+      - MUSICBRAINZ_PERL_LOCAL_LIB=${MUSICBRAINZ_PERL_LOCAL_LIB:-/musicbrainz-server/perl_modules}

--- a/compose/musicbrainz-dev.yml
+++ b/compose/musicbrainz-dev.yml
@@ -9,5 +9,7 @@ services:
     volumes:
       - ${MUSICBRAINZ_SERVER_LOCAL_ROOT:?Missing path of musicbrainz-server working copy}:/musicbrainz-server
     environment:
+      - MUSICBRAINZ_CATALYST_DEBUG=${MUSICBRAINZ_CATALYST_DEBUG:-0}
+      - MUSICBRAINZ_DEVELOPMENT_SERVER=${MUSICBRAINZ_DEVELOPMENT_SERVER:-1}
       - PERL_CPANM_HOME=${MUSICBRAINZ_PERL_CPANM_HOME:-/musicbrainz-server/.cpanm}
       - MUSICBRAINZ_PERL_LOCAL_LIB=${MUSICBRAINZ_PERL_LOCAL_LIB:-/musicbrainz-server/perl_modules}

--- a/compose/musicbrainz-development.yml
+++ b/compose/musicbrainz-development.yml
@@ -1,8 +1,0 @@
-version: '3.1'
-
-# Description: Run MusicBrainz Server in standalone mode for development purpose
-
-services:
-  musicbrainz:
-    environment:
-      - DEVELOPMENT_MUSICBRAINZ_DOCKER=1

--- a/compose/musicbrainz-standalone.yml
+++ b/compose/musicbrainz-standalone.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+# Description: Run MusicBrainz Server in standalone mode for test purpose
+
+services:
+  musicbrainz:
+    environment:
+      - MUSICBRAINZ_STANDALONE_SERVER=1


### PR DESCRIPTION
This patch distinguishes _test_ setup from _development_ setup:
    
* test setup to run server in standalone mode with sample data,
* development setup to run any local working copy of musicbrainz-server.
