### PR TITLE
Fix error checking when creating database

### DIFF
--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -77,7 +77,15 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
         for F in MD5SUMS ${DUMP_FILES[@]}; do
             wget $WGET_OPTIONS -P /media/dbdump "$FTP_MB/data/$IMPORT/$LATEST/$F"
         done
-        pushd /media/dbdump && md5sum -c MD5SUMS && popd
+        cd /media/dbdump
+        for F in ${DUMP_FILES[@]}; do
+            MD5SUM=$(md5sum -b "$F")
+            grep -Fqx "$MD5SUM" MD5SUMS ||
+                echo "$0: unmatched checksum:" &&
+                echo "$MD5SUM" &&
+                exit 70 # EX_SOFTWARE
+        done
+        cd -
     elif [[ $IMPORT == "sample" ]]; then
         for F in ${DUMP_FILES[@]}; do
             wget $WGET_OPTIONS -P /media/dbdump "$FTP_MB/data/$IMPORT/$LATEST/$F"

--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -91,10 +91,11 @@ if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
     mkdir -p $TMP_DIR
     cd /media/dbdump
 
-    # if the import fails because the DB does not exist yet such as when the DB
-    # has been dropped, InitDb will be called again with the createdb flag
-    /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]} ||
-    /musicbrainz-server/admin/InitDb.pl --createdb --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
+    INITDB_OPTIONS='--echo --import'
+    if ! /musicbrainz-server/script/database_exists MAINTENANCE; then
+        INITDB_OPTIONS="--createdb $INITDB_OPTIONS"
+    fi
+    /musicbrainz-server/admin/InitDb.pl $INITDB_OPTIONS -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
 else
     echo "no dumps found or dumps are incomplete"
 fi

--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -54,16 +54,16 @@ TMP_DIR=/media/dbdump/tmp
 case "$IMPORT" in
     fullexport  )
         DUMP_FILES=(
-        mbdump.tar.bz2
-        mbdump-cdstubs.tar.bz2
-        mbdump-cover-art-archive.tar.bz2
-        mbdump-derived.tar.bz2
-        mbdump-stats.tar.bz2
-        mbdump-wikidocs.tar.bz2
+            mbdump.tar.bz2
+            mbdump-cdstubs.tar.bz2
+            mbdump-cover-art-archive.tar.bz2
+            mbdump-derived.tar.bz2
+            mbdump-stats.tar.bz2
+            mbdump-wikidocs.tar.bz2
         );;
     sample      )
         DUMP_FILES=(
-        mbdump-sample.tar.xz
+            mbdump-sample.tar.xz
         );;
 esac
 

--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -92,9 +92,9 @@ if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
     cd /media/dbdump
 
     # if the import fails because the DB does not exist yet such as when the DB
-    # has been dropped, InitDb will be called again with the create flag
+    # has been dropped, InitDb will be called again with the createdb flag
     /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]} ||
-    /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
+    /musicbrainz-server/admin/InitDb.pl --createdb --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
 else
     echo "no dumps found or dumps are incomplete"
 fi

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -77,7 +77,15 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
         for F in MD5SUMS ${DUMP_FILES[@]}; do
             wget $WGET_OPTIONS -P /media/dbdump "$FTP_MB/data/$IMPORT/$LATEST/$F"
         done
-        pushd /media/dbdump && md5sum -c MD5SUMS && popd
+        cd /media/dbdump
+        for F in ${DUMP_FILES[@]}; do
+            MD5SUM=$(md5sum -b "$F")
+            grep -Fqx "$MD5SUM" MD5SUMS ||
+                echo "$0: unmatched checksum:" &&
+                echo "$MD5SUM" &&
+                exit 70 # EX_SOFTWARE
+        done
+        cd -
     elif [[ $IMPORT == "sample" ]]; then
         for F in ${DUMP_FILES[@]}; do
             wget $WGET_OPTIONS -P /media/dbdump "$FTP_MB/data/$IMPORT/$LATEST/$F"

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -91,10 +91,11 @@ if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
     mkdir -p $TMP_DIR
     cd /media/dbdump
 
-    # if the import fails because the DB does not exist yet such as when the DB
-    # has been dropped, InitDb will be called again with the createdb flag
-    /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]} ||
-    /musicbrainz-server/admin/InitDb.pl --createdb --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
+    INITDB_OPTIONS='--echo --import'
+    if ! /musicbrainz-server/script/database_exists MAINTENANCE; then
+        INITDB_OPTIONS="--createdb $INITDB_OPTIONS"
+    fi
+    /musicbrainz-server/admin/InitDb.pl $INITDB_OPTIONS -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
 else
     echo "no dumps found or dumps are incomplete"
 fi

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -54,16 +54,16 @@ TMP_DIR=/media/dbdump/tmp
 case "$IMPORT" in
     fullexport  )
         DUMP_FILES=(
-        mbdump.tar.bz2
-        mbdump-cdstubs.tar.bz2
-        mbdump-cover-art-archive.tar.bz2
-        mbdump-derived.tar.bz2
-        mbdump-stats.tar.bz2
-        mbdump-wikidocs.tar.bz2
+            mbdump.tar.bz2
+            mbdump-cdstubs.tar.bz2
+            mbdump-cover-art-archive.tar.bz2
+            mbdump-derived.tar.bz2
+            mbdump-stats.tar.bz2
+            mbdump-wikidocs.tar.bz2
         );;
     sample      )
         DUMP_FILES=(
-        mbdump-sample.tar.xz
+            mbdump-sample.tar.xz
         );;
 esac
 

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -92,9 +92,9 @@ if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
     cd /media/dbdump
 
     # if the import fails because the DB does not exist yet such as when the DB
-    # has been dropped, InitDb will be called again with the create flag
+    # has been dropped, InitDb will be called again with the createdb flag
     /musicbrainz-server/admin/InitDb.pl --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]} ||
-    /musicbrainz-server/admin/InitDb.pl --create --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
+    /musicbrainz-server/admin/InitDb.pl --createdb --echo --import -- --skip-editor --tmp-dir $TMP_DIR ${DUMP_FILES[@]}
 else
     echo "no dumps found or dumps are incomplete"
 fi


### PR DESCRIPTION
Fix:
- checking for database before running `admin/InitDb.pl`,
- computing appropriate MD5 checksums and exiting on mismatch.