### PR TITLE
Update nodejs

### DIFF
--- a/musicbrainz-dockerfile/Dockerfile
+++ b/musicbrainz-dockerfile/Dockerfile
@@ -32,17 +32,10 @@ RUN git clone https://github.com/metabrainz/musicbrainz-server.git musicbrainz-s
     cd musicbrainz-server && \
     git checkout v-2020-04-13
 
-RUN cd musicbrainz-server && \
-    cp docker/yarn_pubkey.txt /tmp && \
-    cd /tmp && \
-    apt-key add yarn_pubkey.txt && \
-    apt-key adv --keyserver hkps.pool.sks-keyservers.net --refresh-keys Yarn && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update -o Dir::Etc::sourcelist="sources.list.d/yarn.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
-    curl -sLO https://deb.nodesource.com/node_8.x/pool/main/n/nodejs/nodejs_8.11.3-1nodesource1_amd64.deb && \
-    dpkg -i nodejs_8.11.3-1nodesource1_amd64.deb && \
-    apt remove -y cmdtest && \
-    apt-get install -y yarn
+RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    apt-get install --yes --no-install-recommends nodejs yarn
 
 RUN cd /musicbrainz-server/ && \
     eval $( perl -Mlocal::lib) && cpanm --installdeps --notest .


### PR DESCRIPTION
selenium-webdriver requires Node.js >= 10.15.0

```
Step 21/26 : RUN cd /musicbrainz-server/ && yarn install --production &&     eval $( perl -Mlocal::lib) && /musicbrainz-server/script/compile_resources.sh
 ---> Running in 69bdb9a9cce9
yarn install v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.7: The platform "linux" is incompatible with this module.
info "fsevents@1.2.7" is an optional dependency and failed compatibility check. Excluding it from installation.
error selenium-webdriver@4.0.0-alpha.5: The engine "node" is incompatible with this module. Expected version ">= 10.15.0". Got "8.11.3"
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error Found incompatible module.
ERROR: Service 'musicbrainz' failed to build: The command '/bin/sh -c cd /musicbrainz-server/ && yarn install --production &&     eval $( perl -Mlocal::lib) && /musicbrainz-server/script/compile_resources.sh' returned a non-zero code: 1
```