### PR TITLE
Document (and lint) admin helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,21 +350,21 @@ Replication is not applicable to development setup.
 There are two directories with helper scripts:
 
 * [`admin/`](admin/) contains helper scripts to be run from the host.
-  For more information, try:
+  For more information, use the `--help` option:
 
   ```bash
   admin/check-search-indexes --help
   admin/delete-search-indexes --help
   ```
 
-  See [Docker Compose overrides](#docker-compose-overrides) for more
-  information about `admin/configure`.
-  See [Enable live indexing](#enable-live-indexing) for more
-  information about `admin/create-amqp-extension` and
-  `admin/setup-amqp-triggers`.
-
-<!-- TODO: add help option to admin/create-amqp-extension -->
-<!-- TODO: add help option to admin/setup-amqp-triggers -->
+  See also:
+  * [Docker Compose overrides](#docker-compose-overrides) for more
+    information about `admin/configure`.
+  * [Enable live indexing](#enable-live-indexing) for more information
+    about `admin/create-amqp-extension`
+    and `admin/setup-amqp-triggers`.
+  * [Enable replication](#enable-replication) for more information
+    about `admin/set-replication-token`.
 
 * [`build/musicbrainz/scripts/`](build/musicbrainz/scripts/) contains
   helper scripts to be run from the container attached to the service

--- a/admin/check-search-indexes
+++ b/admin/check-search-indexes
@@ -74,7 +74,7 @@ if [[ $# -eq 1 && $1 =~ -*h(elp)? ]]
 then
   echo "$HELP"
   exit
-elif [ $# -eq 1 -a "$1" = 'all' ]
+elif [[ $# -eq 1 && $1 == all ]]
 then
   cores=( ${!queries[@]} )
 else

--- a/admin/check-search-indexes
+++ b/admin/check-search-indexes
@@ -8,6 +8,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/common.inc.bash"
 HELP=$(cat <<EOH
 Usage: $SCRIPT_NAME all
    or: $SCRIPT_NAME CORE...
+   or: $SCRIPT_NAME --help
 
 For each of MusicBrainz Solr cores/collections,
 compare the count of existing documents in PostgreSQL,
@@ -69,7 +70,7 @@ fi
 
 declare -a cores
 
-if [ $# -eq 1 -a \( "$1" = '-h' -o "$1" = '--help' \) ]
+if [[ $# -eq 1 && $1 =~ -*h(elp)? ]]
 then
   echo "$HELP"
   exit

--- a/admin/check-search-indexes
+++ b/admin/check-search-indexes
@@ -131,7 +131,7 @@ done
 declare -a ascending_cores=( $(
   for core in "${!counts[@]}"
   do
-    echo $core ${counts["$core"]}
+    echo "$core ${counts["$core"]}"
   done | sort -n -k2 | sed 's/ .*$//'
 ) )
 
@@ -157,7 +157,7 @@ for core in json_status:
 sep="|"
 for core in "${ascending_cores[@]}"
 do
-  if [ ${counts[$core]} -eq ${indexed_docs[$core]:-0} ]
+  if [[ ${counts[$core]} -eq ${indexed_docs[$core]:-0} ]]
   then
     echo "$core${sep}OK$sep${indexed_docs[$core]:-0}$sep/${counts[$core]}"
   else

--- a/admin/check-search-indexes
+++ b/admin/check-search-indexes
@@ -65,7 +65,7 @@ if [ $# -eq 0 ]
 then
   echo >&2 "$SCRIPT_NAME: missing argument"
   echo >&2 "Try '$SCRIPT_NAME --help' for usage."
-  exit 64
+  exit 64 # EX_USAGE
 fi
 
 declare -a cores
@@ -73,7 +73,7 @@ declare -a cores
 if [[ $# -eq 1 && $1 =~ -*h(elp)? ]]
 then
   echo "$HELP"
-  exit
+  exit 0 # EX_OK
 elif [[ $# -eq 1 && $1 == all ]]
 then
   cores=( ${!queries[@]} )
@@ -85,7 +85,7 @@ else
     then
       echo >&2 "$SCRIPT_NAME: unrecognized core '$1'"
       echo >&2 "Try '$SCRIPT_NAME --help' for usage."
-      exit 64
+      exit 64 # EX_USAGE
     else
       cores+=( $1 )
       shift
@@ -101,7 +101,7 @@ then
   echo >&2 "$SCRIPT_NAME: cannot count existing documents: " \
            "the Docker Compose service 'db' is not up"
   echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d' from '$MB_DOCKER_ROOT'"
-  exit 69
+  exit 69 # EX_UNAVAILABLE
 fi
 
 service_containers="$($DOCKER_COMPOSE_CMD ps indexer 2>/dev/null)"
@@ -110,7 +110,7 @@ then
   echo >&2 "$SCRIPT_NAME: cannot count indexed documents: " \
            "the Docker Compose service 'indexer' is not up"
   echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d' from '$MB_DOCKER_ROOT'"
-  exit 69
+  exit 69 # EX_UNAVAILABLE
 fi
 
 # Count existing documents by core in PostgreSQL

--- a/admin/configure
+++ b/admin/configure
@@ -70,7 +70,7 @@ function scan_files {
 
   for file in local/**/*.yml
   do
-    handle="$(echo ${file%.yml} | tr / -)"
+    handle="$(echo "${file%.yml}" | tr / -)"
     file_handle["$file"]="$handle"
     handle_file["$handle"]="$file"
   done
@@ -160,7 +160,7 @@ case "$1" in
     scan_files
 
     declare -a compose_files
-    if [ $command != 'with' ]
+    if [[ $command != with ]]
     then
       if [ -f "$MB_DOCKER_ROOT/.env" ] \
         && grep -q '^COMPOSE_FILE=' "$MB_DOCKER_ROOT/.env"
@@ -176,18 +176,18 @@ case "$1" in
       if [ "${file_handle[$1]-}" ]
       then
         compose_files=( ${compose_files[@]/$1} )
-        if [ $command != 'rm' ]
+        if [[ $command != rm ]]
         then
           compose_files+=( "$1" )
         fi
       elif [ "${handle_file[$1]-}" ]
       then
         compose_files=( ${compose_files[@]/${handle_file[$1]}} )
-        if [ $command != 'rm' ]
+        if [[ $command != rm ]]
         then
           compose_files+=( "${handle_file[$1]}" )
         fi
-      elif [ $command = 'rm' ]
+      elif [[ $command == rm ]]
       then
         echo "Ignore obsolete/missing '$1'"
       else

--- a/admin/configure
+++ b/admin/configure
@@ -40,7 +40,7 @@ if [ $# -eq 0 ]
 then
   echo >&2 "$SCRIPT_NAME: missing argument"
   echo >&2 "Try '$SCRIPT_NAME help' for usage."
-  exit 64
+  exit 64 # EX_USAGE
 fi
 
 declare -a file_path=()
@@ -108,13 +108,13 @@ function print_file_list {
 case "$1" in
   help|--help|-h)
     echo "$HELP"
-    exit
+    exit 0 # EX_OK
     ;;
   list          )
     scan_files
     echo Available compose files:
     print_file_list "${file_path[@]}"
-    exit
+    exit 0 # EX_OK
     ;;
   show          )
     scan_files
@@ -146,7 +146,7 @@ case "$1" in
     echo
     echo "Referred-to compose file(s):"
     print_file_list "${compose_files[@]}"
-    exit
+    exit 0 # EX_OK
     ;;
   with |add |rm )
     command=$1
@@ -155,7 +155,7 @@ case "$1" in
     then
       echo >&2 "$SCRIPT_NAME: missing argument"
       echo >&2 "Try '$SCRIPT_NAME help' for usage."
-      exit 64
+      exit 64 # EX_USAGE
     fi
     scan_files
 
@@ -193,7 +193,7 @@ case "$1" in
       else
         echo >&2 "$SCRIPT_NAME: unknown file/handle: '$1'"
         echo >&2 "Try '$SCRIPT_NAME help' for usage."
-        exit 64
+        exit 64 # EX_USAGE
       fi
       shift
     done
@@ -203,12 +203,12 @@ case "$1" in
     sed -i.bak -e '/^COMPOSE_FILE=/d' .env && rm -f .env.bak
     echo "COMPOSE_FILE=$(IFS=:; echo "${compose_files[*]}")" >> .env
     echo "Successfully set/updated COMPOSE_FILE in '$MB_DOCKER_ROOT/.env'."
-    exit
+    exit 0 # EX_OK
     ;;
   *             )
     echo >&2 "$SCRIPT_NAME: unknown command: '$1'"
     echo >&2 "Try '$SCRIPT_NAME help' for usage."
-    exit 64
+    exit 64 # EX_USAGE
     ;;
 esac
 

--- a/admin/configure
+++ b/admin/configure
@@ -9,6 +9,8 @@ HELP=$(cat <<EOH
 Usage: $SCRIPT_NAME <command> [<args>]
 
 Commands:
+  help          Print this help message
+
   list          List available compose files with handle, path and description
   show          Show COMPOSE_FILE from both .env file and environment variable
 

--- a/admin/create-amqp-extension
+++ b/admin/create-amqp-extension
@@ -6,16 +6,20 @@ set -e -u
 source "$(dirname "${BASH_SOURCE[0]}")/lib/common.inc.bash"
 
 HELP=$(cat <<EOH
-Usage: $SCRIPT_NAME
+Usage: $SCRIPT_NAME [--help]
 
 Create 'amqp' extension (with broker) in the database.
 EOH
 )
 
-if [ $# -ne 0 ]
+if [[ $# -ne 0 && $1 =~ -*h(elp)? ]]
 then
-  echo >&2 "$SCRIPT_NAME: too many arguments"
-  echo >&2 "$HELP"
+  echo "$HELP"
+  exit
+elif [[ $# -ne 0 ]]
+then
+  echo >&2 "$SCRIPT_NAME: unrecognized argument: $1"
+  echo >&2 "Try '$SCRIPT_NAME help' for usage."
   exit 64
 fi
 

--- a/admin/create-amqp-extension
+++ b/admin/create-amqp-extension
@@ -28,7 +28,9 @@ REMOTE_SQL_FILE=/tmp/CreateExtensionAMQP.sql
 
 if ! $DOCKER_COMPOSE_CMD ps indexer | grep -qw 'Up'
 then
-  echo >&2 "$SCRIPT_NAME: cannot install: 'indexer' is not a running Docker Compose service"
+  echo >&2 "$SCRIPT_NAME: cannot install: " \
+           "the Docker Compose service 'indexer' is not up"
+  echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d indexer' from '$MB_DOCKER_ROOT'"
   exit 69
 fi
 
@@ -43,7 +45,8 @@ fi
 
 if $DOCKER_COMPOSE_CMD exec db test -e "$REMOTE_SQL_FILE"
 then
-  echo >&2 "$SCRIPT_NAME: cannot install: file '$REMOTE_SQL_FILE' exists in 'db' Docker Compose service"
+  echo >&2 "$SCRIPT_NAME: cannot install: " \
+           "file '$REMOTE_SQL_FILE' exists in 'db' Docker Compose service"
   echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
   echo >&2 "Remove this file if you are sure the script is not still running:"
   echo >&2 "    $DOCKER_COMPOSE_CMD exec db rm -fv $(printf %q "$REMOTE_SQL_FILE")"

--- a/admin/create-amqp-extension
+++ b/admin/create-amqp-extension
@@ -35,12 +35,18 @@ fi
 if [ -e "$LOCAL_SQL_FILE" ]
 then
   echo >&2 "$SCRIPT_NAME: cannot install: file '$LOCAL_SQL_FILE' exists"
+  echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
+  echo >&2 "Remove this file if you are sure the script is not still running:"
+  echo >&2 "    rm -fv $(printf %q "$LOCAL_SQL_FILE")"
   exit 70
 fi
 
 if $DOCKER_COMPOSE_CMD exec db test -e "$REMOTE_SQL_FILE"
 then
   echo >&2 "$SCRIPT_NAME: cannot install: file '$REMOTE_SQL_FILE' exists in 'db' Docker Compose service"
+  echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
+  echo >&2 "Remove this file if you are sure the script is not still running:"
+  echo >&2 "    $DOCKER_COMPOSE_CMD exec db rm -fv $(printf %q "$REMOTE_SQL_FILE")"
   exit 70
 fi
 

--- a/admin/create-amqp-extension
+++ b/admin/create-amqp-extension
@@ -15,12 +15,12 @@ EOH
 if [[ $# -ne 0 && $1 =~ -*h(elp)? ]]
 then
   echo "$HELP"
-  exit
+  exit 0 # EX_OK
 elif [[ $# -ne 0 ]]
 then
   echo >&2 "$SCRIPT_NAME: unrecognized argument: $1"
   echo >&2 "Try '$SCRIPT_NAME help' for usage."
-  exit 64
+  exit 64 # EX_USAGE
 fi
 
 LOCAL_SQL_FILE="$(dirname "${BASH_SOURCE[0]}")/.create-amqp-extension.sql"
@@ -31,7 +31,7 @@ then
   echo >&2 "$SCRIPT_NAME: cannot install: " \
            "the Docker Compose service 'indexer' is not up"
   echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d indexer' from '$MB_DOCKER_ROOT'"
-  exit 69
+  exit 69 # EX_UNAVAILABLE
 fi
 
 if [ -e "$LOCAL_SQL_FILE" ]
@@ -40,7 +40,7 @@ then
   echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
   echo >&2 "Remove this file if you are sure the script is not still running:"
   echo >&2 "    rm -fv $(printf %q "$LOCAL_SQL_FILE")"
-  exit 70
+  exit 70 # EX_SOFTWARE
 fi
 
 if $DOCKER_COMPOSE_CMD exec db test -e "$REMOTE_SQL_FILE"
@@ -50,7 +50,7 @@ then
   echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
   echo >&2 "Remove this file if you are sure the script is not still running:"
   echo >&2 "    $DOCKER_COMPOSE_CMD exec db rm -fv $(printf %q "$REMOTE_SQL_FILE")"
-  exit 70
+  exit 70 # EX_SOFTWARE
 fi
 
 echo "Installing indexer AMQP extension into PostgreSQL ..."

--- a/admin/delete-search-indexes
+++ b/admin/delete-search-indexes
@@ -24,7 +24,7 @@ if [ $# -eq 0 ]
 then
   echo >&2 "$SCRIPT_NAME: missing argument"
   echo >&2 "Try '$SCRIPT_NAME --help' for usage."
-  exit 64
+  exit 64 # EX_USAGE
 fi
 
 declare -A all_cores=(
@@ -38,7 +38,7 @@ declare -a cores
 if [[ $# -eq 1 && $1 =~ -*h(elp)? ]]
 then
   echo "$HELP"
-  exit
+  exit 0 # EX_OK
 elif [[ $# -eq 1 && $1 == all ]]
 then
   cores=( ${!all_cores[@]} )
@@ -50,7 +50,7 @@ else
     then
       echo >&2 "$SCRIPT_NAME: unrecognized core '$1'"
       echo >&2 "Try '$SCRIPT_NAME --help' for usage."
-      exit 64
+      exit 64 # EX_USAGE
     else
       cores+=( $1 )
       shift
@@ -66,7 +66,7 @@ then
   echo >&2 "$SCRIPT_NAME: cannot delete indexed documents: " \
            "the Docker Compose service 'search' is not up"
   echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d search' from '$MB_DOCKER_ROOT'"
-  exit 69
+  exit 69 # EX_UNAVAILABLE
 fi
 
 # For each collection/core, delete all indexed documents

--- a/admin/delete-search-indexes
+++ b/admin/delete-search-indexes
@@ -65,7 +65,7 @@ if ! echo "$service_containers" | grep -qw 'Up'
 then
   echo >&2 "$SCRIPT_NAME: cannot delete indexed documents: " \
            "the Docker Compose service 'search' is not up"
-  echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d' from '$MB_DOCKER_ROOT'"
+  echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d search' from '$MB_DOCKER_ROOT'"
   exit 69
 fi
 

--- a/admin/delete-search-indexes
+++ b/admin/delete-search-indexes
@@ -8,6 +8,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/common.inc.bash"
 HELP=$(cat <<EOH
 Usage: $SCRIPT_NAME all
    or: $SCRIPT_NAME CORE...
+   or: $SCRIPT_NAME --help
 
 For each of MusicBrainz Solr cores/collections,
 delete all indexed documents from Solr server.
@@ -34,7 +35,7 @@ declare -A all_cores=(
 
 declare -a cores
 
-if [ $# -eq 1 -a \( "$1" = '-h' -o "$1" = '--help' \) ]
+if [[ $# -eq 1 && $1 =~ -*h(elp)? ]]
 then
   echo "$HELP"
   exit

--- a/admin/delete-search-indexes
+++ b/admin/delete-search-indexes
@@ -39,7 +39,7 @@ if [[ $# -eq 1 && $1 =~ -*h(elp)? ]]
 then
   echo "$HELP"
   exit
-elif [ $# -eq 1 -a "$1" = 'all' ]
+elif [[ $# -eq 1 && $1 == all ]]
 then
   cores=( ${!all_cores[@]} )
 else

--- a/admin/lib/common.inc.bash
+++ b/admin/lib/common.inc.bash
@@ -4,7 +4,7 @@ if ((BASH_VERSINFO[0] < 4))
 then
   echo >&2 "$SCRIPT_NAME: at least version 4 of bash is required"
   echo >&2 "Make sure this version of bash comes first in \$PATH"
-  exit 69
+  exit 69 # EX_UNAVAILABLE
 fi
 
 MB_DOCKER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)
@@ -29,7 +29,7 @@ then
     echo >&2 "$SCRIPT_NAME: cannot set docker command: please either"
     echo >&2 "  * add the user '$USER' to the group 'sudo' or 'wheel'"
     echo >&2 "  * or set the variable \$DOCKER_CMD"
-    exit 77
+    exit 77 # EX_NOPERM
   fi
 fi
 
@@ -48,7 +48,7 @@ then
     echo >&2 "$SCRIPT_NAME: cannot set docker-compose command: please either"
     echo >&2 "  * add the user '$USER' to the group 'sudo' or 'wheel'"
     echo >&2 "  * or set the variable \$DOCKER_COMPOSE_CMD"
-    exit 77
+    exit 77 # EX_NOPERM
   fi
 fi
 

--- a/admin/lib/common.inc.bash
+++ b/admin/lib/common.inc.bash
@@ -10,7 +10,7 @@ fi
 MB_DOCKER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)
 
 cd "$MB_DOCKER_ROOT" || {
-  echo >&2 "$SCRIPT_NAME: fail to change directory to '$MB_DOCKER_ROOT'";
+  echo >&2 "$SCRIPT_NAME: fail to change directory to '$MB_DOCKER_ROOT'"
   exit 70 # EX_SOFTWARE
 }
 

--- a/admin/set-replication-token
+++ b/admin/set-replication-token
@@ -66,7 +66,7 @@ echo 'Thank you!'
 declare -r token_default_path="$MB_DOCKER_ROOT/local/secrets/metabrainz_access_token"
 declare -r TOKEN_PATH="${METABRAINZ_ACCESS_TOKEN_PATH:-$token_default_path}"
 
-if [ -f "$TOKEN_PATH" -a "$overwrite" -ne 1 ]
+if [[ -f $TOKEN_PATH && $overwrite -ne 1 ]]
 then
   echo >&2 "$SCRIPT_NAME: token file already exists at: '$TOKEN_PATH'"
   echo >&2 "Try '$SCRIPT_NAME --help' for usage."

--- a/admin/set-replication-token
+++ b/admin/set-replication-token
@@ -33,12 +33,12 @@ then
       ;;
     -h|--help|help)
       echo "$HELP"
-      exit
+      exit 0 # EX_OK
       ;;
     *)
       echo >&2 "$SCRIPT_NAME: unrecognized argument: '$1'"
       echo >&2 "Try '$SCRIPT_NAME --help' for usage."
-      exit 64
+      exit 64 # EX_USAGE
       ;;
   esac
 fi
@@ -47,7 +47,7 @@ if [ $# -ne 0 ]
 then
   echo >&2 "$SCRIPT_NAME: too many arguments"
   echo >&2 "Try '$SCRIPT_NAME --help' for usage."
-  exit 64
+  exit 64 # EX_USAGE
 fi
 
 declare token=''
@@ -70,7 +70,7 @@ if [[ -f $TOKEN_PATH && $overwrite -ne 1 ]]
 then
   echo >&2 "$SCRIPT_NAME: token file already exists at: '$TOKEN_PATH'"
   echo >&2 "Try '$SCRIPT_NAME --help' for usage."
-  exit 73
+  exit 73 # EX_CANTCREAT
 fi
 
 mkdir -p "$(dirname "$TOKEN_PATH")"

--- a/admin/set-replication-token
+++ b/admin/set-replication-token
@@ -12,6 +12,7 @@ Read token and write it to local/secrets/metabrainz_access_token.
 
 Option:
   -f, --force   Overwrite existing token if any.
+  -h, --help    Print this help message
 
 Environment variable:
   METABRAINZ_ACCESS_TOKEN_PATH

--- a/admin/setup-amqp-triggers
+++ b/admin/setup-amqp-triggers
@@ -20,7 +20,7 @@ if [ $# -ne 1 ]
 then
   echo >&2 "$SCRIPT_NAME: wrong number of arguments"
   echo >&2 "Try '$SCRIPT_NAME help' for usage."
-  exit 64
+  exit 64 # EX_USAGE
 fi
 
 LOCAL_TRIGGERS_DIR="$(dirname "${BASH_SOURCE[0]}")/.setup-amqp-triggers-sql"
@@ -33,7 +33,7 @@ case "$1" in
       echo >&2 "$SCRIPT_NAME: cannot clean: " \
                "the Docker Compose service 'musicbrainz' is not up"
       echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d musicbrainz' from '$MB_DOCKER_ROOT'"
-      exit 69
+      exit 69 # EX_UNAVAILABLE
     fi
 
     echo "Cleaning indexer triggers install/uninstall scripts up ..."
@@ -47,7 +47,7 @@ case "$1" in
       echo >&2 "$SCRIPT_NAME: cannot install: " \
                "the Docker Compose service 'indexer' is not up"
       echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d indexer' from '$MB_DOCKER_ROOT'"
-      exit 69
+      exit 69 # EX_UNAVAILABLE
     fi
 
     if [ -e "$LOCAL_TRIGGERS_DIR" ]
@@ -56,7 +56,7 @@ case "$1" in
       echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
       echo >&2 "Remove this file if you are sure the script is not still running:"
       echo >&2 "    rm -frv $(printf %q "$LOCAL_TRIGGERS_DIR")"
-      exit 70
+      exit 70 # EX_SOFTWARE
     fi
 
     if $DOCKER_COMPOSE_CMD exec musicbrainz test -e "$REMOTE_TRIGGERS_DIR"
@@ -65,7 +65,7 @@ case "$1" in
       echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
       echo >&2 "Revert partial installation if you are sure the script is not still running:"
       echo >&2 "    $SCRIPT_NAME uninstall"
-      exit 70
+      exit 70 # EX_SOFTWARE
     fi
 
     echo "Installing indexer triggers ..."
@@ -92,13 +92,13 @@ case "$1" in
       echo >&2 "$SCRIPT_NAME: cannot uninstall: " \
                "the Docker Compose service 'musicbrainz' is not up"
       echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d musicbrainz' from '$MB_DOCKER_ROOT'"
-      exit 69
+      exit 69 # EX_UNAVAILABLE
     fi
 
     if $DOCKER_COMPOSE_CMD exec musicbrainz test ! -e "$REMOTE_TRIGGERS_DIR"
     then
       echo >&2 "$SCRIPT_NAME: cannot uninstall: file '$REMOTE_TRIGGERS_DIR' does not exist"
-      exit 70
+      exit 70 # EX_SOFTWARE
     fi
 
     echo "Uninstalling indexer triggers ..."
@@ -109,12 +109,12 @@ case "$1" in
     ;;
   help|-h|--help)
     echo "$HELP"
-    exit
+    exit 0 # EX_OK
     ;;
   *         )
     echo >&2 "$SCRIPT_NAME: unrecognized command '$1'"
   echo >&2 "Try '$SCRIPT_NAME help' for usage."
-    exit 64
+    exit 64 # EX_USAGE
     ;;
 esac
 

--- a/admin/setup-amqp-triggers
+++ b/admin/setup-amqp-triggers
@@ -49,12 +49,18 @@ case "$1" in
     if [ -e "$LOCAL_TRIGGERS_DIR" ]
     then
       echo >&2 "$SCRIPT_NAME: cannot install: file '$LOCAL_TRIGGERS_DIR' exists"
+      echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
+      echo >&2 "Remove this file if you are sure the script is not still running:"
+      echo >&2 "    rm -frv $(printf %q "$LOCAL_TRIGGERS_DIR")"
       exit 70
     fi
 
     if $DOCKER_COMPOSE_CMD exec musicbrainz test -e "$REMOTE_TRIGGERS_DIR"
     then
       echo >&2 "$SCRIPT_NAME: cannot install: file '$REMOTE_TRIGGERS_DIR' exists in 'musicbrainz' docker compose service"
+      echo >&2 "Either $SCRIPT_NAME is already running or stopped before its time."
+      echo >&2 "Revert partial installation if you are sure the script is not still running:"
+      echo >&2 "    $SCRIPT_NAME uninstall"
       exit 70
     fi
 

--- a/admin/setup-amqp-triggers
+++ b/admin/setup-amqp-triggers
@@ -30,7 +30,9 @@ case "$1" in
   clean     )
     if ! $DOCKER_COMPOSE_CMD ps musicbrainz | grep -qw 'Up'
     then
-      echo >&2 "$SCRIPT_NAME: cannot clean: 'musicbrainz' is not a running docker compose service"
+      echo >&2 "$SCRIPT_NAME: cannot clean: " \
+               "the Docker Compose service 'musicbrainz' is not up"
+      echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d musicbrainz' from '$MB_DOCKER_ROOT'"
       exit 69
     fi
 
@@ -42,7 +44,9 @@ case "$1" in
   install   )
     if ! $DOCKER_COMPOSE_CMD ps indexer | grep -qw 'Up'
     then
-      echo >&2 "$SCRIPT_NAME: cannot install: 'indexer' is not a running docker compose service"
+      echo >&2 "$SCRIPT_NAME: cannot install: " \
+               "the Docker Compose service 'indexer' is not up"
+      echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d indexer' from '$MB_DOCKER_ROOT'"
       exit 69
     fi
 
@@ -85,7 +89,9 @@ case "$1" in
   uninstall )
     if ! $DOCKER_COMPOSE_CMD ps musicbrainz | grep -qw 'Up'
     then
-      echo >&2 "$SCRIPT_NAME: cannot uninstall: 'musicbrainz' is not a running docker compose service"
+      echo >&2 "$SCRIPT_NAME: cannot uninstall: " \
+               "the Docker Compose service 'musicbrainz' is not up"
+      echo >&2 "Try '$DOCKER_COMPOSE_CMD up -d musicbrainz' from '$MB_DOCKER_ROOT'"
       exit 69
     fi
 

--- a/admin/setup-amqp-triggers
+++ b/admin/setup-amqp-triggers
@@ -6,19 +6,20 @@ set -e -u
 source "$(dirname "${BASH_SOURCE[0]}")/lib/common.inc.bash"
 
 HELP=$(cat <<EOH
-Usage: $SCRIPT_NAME <clean|install|uninstall>
+Usage: $SCRIPT_NAME <clean|install|uninstall|help>
 
 Commands:
   clean       Remove temporary install scripts and uninstall scripts.
   install     Create database triggers and add uninstall scripts.
   uninstall   Drop database triggers and remove uninstall scripts.
+  help        Print this help message
 EOH
 )
 
 if [ $# -ne 1 ]
 then
   echo >&2 "$SCRIPT_NAME: wrong number of arguments"
-  echo >&2 "$HELP"
+  echo >&2 "Try '$SCRIPT_NAME help' for usage."
   exit 64
 fi
 
@@ -94,9 +95,13 @@ case "$1" in
 
     $DOCKER_COMPOSE_CMD exec musicbrainz rm -fr "$REMOTE_TRIGGERS_DIR"
     ;;
+  help|-h|--help)
+    echo "$HELP"
+    exit
+    ;;
   *         )
     echo >&2 "$SCRIPT_NAME: unrecognized command '$1'"
-    echo >&2 "$HELP"
+  echo >&2 "Try '$SCRIPT_NAME help' for usage."
     exit 64
     ;;
 esac


### PR DESCRIPTION
For all helper scripts under `admin/`:

* Support `help` command and `--help` and `-h` options
* Complete usage and error messages
* Update documentation
* Lint scripts a bit using shellcheck