### PR TITLE
Require Linux or macOS as host (or Ubuntu via VirtualBox on Windows) (postpone MBVM-53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ This repo contains everything needed to run a musicbrainz slave server with sear
 * Docker Compose 1.21.1 (or higher), see [how to install Docker Compose](https://docs.docker.com/compose/install/)
 * Git
 * GNU Bash 4 (or higher) utilities, for [admin helper scripts](admin/) only
+  (On macOS, use [Homebrew](https://brew.sh/).)
 * Linux or macOS
   (Windows is not documented yet, it is recommended to use Ubuntu via VirtualBox instead.)
-* [ufw-docker](https://github.com/chaifeng/ufw-docker) or any other way to fix the Docker and UFW security flaw,
-  if you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall.
+
+If you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall:
+* [ufw-docker](https://github.com/chaifeng/ufw-docker) or any other way to fix the Docker and UFW security flaw.
 
 ### External documentation
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This repo contains everything needed to run a musicbrainz slave server with sear
 * Docker Compose 1.21.1 (or higher), see [how to install Docker Compose](https://docs.docker.com/compose/install/)
 * Git
 * GNU Bash 4 (or higher) utilities, for [admin helper scripts](admin/) only
+* Linux or macOS
+  (Windows is not documented yet, it is recommended to use Ubuntu via VirtualBox instead.)
 * [ufw-docker](https://github.com/chaifeng/ufw-docker) or any other way to fix the Docker and UFW security flaw,
   if you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall.
 

--- a/admin/lib/common.inc.bash
+++ b/admin/lib/common.inc.bash
@@ -34,11 +34,9 @@ then
         exit 77 # EX_NOPERM
       fi
       ;;
-    msys*) # Git for Windows
-      DOCKER_CMD='docker'
-      ;;
     *)
       echo >&2 "$SCRIPT_NAME: cannot detect platform to set docker command"
+      echo >&2 "Try setting the variable \$DOCKER_CMD appropriately"
       exit 71 # EX_OSERR
       ;;
   esac
@@ -64,11 +62,9 @@ then
         exit 77 # EX_NOPERM
       fi
       ;;
-    msys*) # Git for Windows
-      DOCKER_COMPOSE_CMD='docker-compose'
-      ;;
     *)
       echo >&2 "$SCRIPT_NAME: cannot detect platform to set docker-compose command"
+      echo >&2 "Try setting the variable \$DOCKER_COMPOSE_CMD appropriately"
       exit 71 # EX_OSERR
       ;;
   esac

--- a/admin/lib/common.inc.bash
+++ b/admin/lib/common.inc.bash
@@ -16,40 +16,62 @@ cd "$MB_DOCKER_ROOT" || {
 
 if [ -z ${DOCKER_CMD:+smt} ]
 then
-  if groups | grep -Eqw 'sudo|wheel'
-  then
-    DOCKER_CMD='sudo docker'
-  elif groups | grep -Eqw 'docker|root'
-  then
-    DOCKER_CMD='docker'
-  elif type sw_vers &>/dev/null && [ "$(sw_vers -productName)" = "Mac OS X" ]
-  then
-    DOCKER_CMD='docker'
-  else
-    echo >&2 "$SCRIPT_NAME: cannot set docker command: please either"
-    echo >&2 "  * add the user '$USER' to the group 'sudo' or 'wheel'"
-    echo >&2 "  * or set the variable \$DOCKER_CMD"
-    exit 77 # EX_NOPERM
-  fi
+  case "$OSTYPE" in
+    darwin*) # Mac OS X
+      DOCKER_CMD='docker'
+      ;;
+    linux*)
+      if groups | grep -Eqw 'sudo|wheel'
+      then
+        DOCKER_CMD='sudo docker'
+      elif groups | grep -Eqw 'docker|root'
+      then
+        DOCKER_CMD='docker'
+      else
+        echo >&2 "$SCRIPT_NAME: cannot set docker command: please either"
+        echo >&2 "  * add the user '$USER' to the group 'sudo' or 'wheel'"
+        echo >&2 "  * or set the variable \$DOCKER_CMD"
+        exit 77 # EX_NOPERM
+      fi
+      ;;
+    msys*) # Git for Windows
+      DOCKER_CMD='docker'
+      ;;
+    *)
+      echo >&2 "$SCRIPT_NAME: cannot detect platform to set docker command"
+      exit 71 # EX_OSERR
+      ;;
+  esac
 fi
 
 if [ -z ${DOCKER_COMPOSE_CMD:+smt} ]
 then
-  if groups | grep -Eqw 'sudo|wheel'
-  then
-    DOCKER_COMPOSE_CMD='sudo docker-compose'
-  elif groups | grep -Eqw 'docker|root'
-  then
-    DOCKER_COMPOSE_CMD='docker-compose'
-  elif type sw_vers &>/dev/null && [ "$(sw_vers -productName)" = "Mac OS X" ]
-  then
-    DOCKER_COMPOSE_CMD='docker-compose'
-  else
-    echo >&2 "$SCRIPT_NAME: cannot set docker-compose command: please either"
-    echo >&2 "  * add the user '$USER' to the group 'sudo' or 'wheel'"
-    echo >&2 "  * or set the variable \$DOCKER_COMPOSE_CMD"
-    exit 77 # EX_NOPERM
-  fi
+  case "$OSTYPE" in
+    darwin*) # Mac OS X
+      DOCKER_COMPOSE_CMD='docker-compose'
+      ;;
+    linux*)
+      if groups | grep -Eqw 'sudo|wheel'
+      then
+        DOCKER_COMPOSE_CMD='sudo docker-compose'
+      elif groups | grep -Eqw 'docker-compose|root'
+      then
+        DOCKER_COMPOSE_CMD='docker-compose'
+      else
+        echo >&2 "$SCRIPT_NAME: cannot set docker-compose command: please either"
+        echo >&2 "  * add the user '$USER' to the group 'sudo' or 'wheel'"
+        echo >&2 "  * or set the variable \$DOCKER_COMPOSE_CMD"
+        exit 77 # EX_NOPERM
+      fi
+      ;;
+    msys*) # Git for Windows
+      DOCKER_COMPOSE_CMD='docker-compose'
+      ;;
+    *)
+      echo >&2 "$SCRIPT_NAME: cannot detect platform to set docker-compose command"
+      exit 71 # EX_OSERR
+      ;;
+  esac
 fi
 
 # vi: set et sts=2 sw=2 ts=2 :


### PR DESCRIPTION
Rather than trying to support a platform we don’t run:
* Add “Linux or macOS” to requirements
* Explain how to install GNU Bash 4 on macOS
* Recommend using Ubuntu via VirtualBox on Windows
* Refactor admin helper scripts to error on unknown platform, but still allow to get around by setting `DOCKER_CMD` and `DOCKER_COMPOSE_CMD` variables in environment
* Leave MBVM-53 open for people interesting in adding instructions for Windows

----

<del>
## Related issues

* https://github.com/metabrainz/musicbrainz-docker/issues/128
* https://github.com/metabrainz/musicbrainz-docker/issues/129

## Related discussions

* https://chatlogs.metabrainz.org/brainzbot/metabrainz/2020-04-23/?msg=4571795&page=1

## To-do list

* [X] Detect Git Bash for Windows: fixed in https://github.com/metabrainz/musicbrainz-docker/commit/c2ea55bc4e73db84e37e74e626f111ecd19e5d6f
* [ ] Solve further issues…
* [ ] Update requirements for a working setup on Windows
      References:
  * https://blog.jayway.com/2017/04/19/running-docker-on-bash-on-windows/
  * https://forums.docker.com/t/weird-error-under-git-bash-msys-solved/9210
  * https://github.com/lfurzewaddock/wsldocker
  * https://www.howtogeek.com/249966/how-to-install-and-use-the-linux-bash-shell-on-windows-10/
  * https://pythonise.com/series/windows-subsystem-for-linux/docker-on-windows-subsystem-for-linux
* [ ] Update instructions to work with that setup too

