### PR TITLE
Install Node prod dependencies only (MBS-10776)

### DIFF
--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -78,6 +78,8 @@ ENV MUSICBRAINZ_CATALYST_DEBUG=0 \
     MUSICBRAINZ_STANDALONE_SERVER=1 \
     MUSICBRAINZ_WEB_SERVER_HOST=localhost \
     MUSICBRAINZ_WEB_SERVER_PORT=5000 \
+    # Needed for yarn to install devDependencies too
+    NODE_ENV=test \
     POSTGRES_USER=musicbrainz \
     POSTGRES_PASSWORD=musicbrainz
 

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -93,10 +93,12 @@ ENV MUSICBRAINZ_CATALYST_DEBUG=0 \
     MUSICBRAINZ_STANDALONE_SERVER=0 \
     MUSICBRAINZ_WEB_SERVER_HOST=localhost \
     MUSICBRAINZ_WEB_SERVER_PORT=5000 \
+    # Needed for yarn to install production dependencies only
+    NODE_ENV=production \
     POSTGRES_USER=musicbrainz \
     POSTGRES_PASSWORD=musicbrainz
 
-RUN yarn install --production \
+RUN yarn install \
     && yarn cache clean \
     && eval "$(perl -Mlocal::lib)" \
     && /musicbrainz-server/script/compile_resources.sh


### PR DESCRIPTION
Use `NODE_ENV=production` environment variable instead of `--production` flag, since `script/compile_resources.sh` is calling `yarn` too.

References:
* MBS-10776
* https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-production-true-false