### PR TITLE
MBVM-52: Allow to load search indexes from FTP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
 before_install:
   - docker-compose build
-  - docker-compose run --rm musicbrainz /createdb.sh -fetch -sample
+  - docker-compose run --rm musicbrainz createdb.sh -fetch -sample
   - docker-compose up --quiet-pull -d
 
 script:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ If you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall:
 * Current DB_SCHEMA_SEQUENCE: [25](build/musicbrainz/DBDefs.pm#L112)
 * Postgres Version: [9.5](docker-compose.yml)
   (can be changed by setting the environment variable `POSTGRES_VERSION`)
-* MB Solr search server: [3.1.1](build/solr/Dockerfile#L1)
+* MB Solr search server: [3.1.1](docker-compose.yml#L67)
+  (can be changed by setting the environment variable `MB_SOLR_VERSION`)
 * Search Index Rebuilder: [1.0.2](build/sir/Dockerfile#L31)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ sudo docker-compose build
 Download latest full data dumps and create the database with:
 
 ```bash
-sudo docker-compose run --rm musicbrainz /createdb.sh -fetch
+sudo docker-compose run --rm musicbrainz createdb.sh -fetch
 ```
 
 <!-- TODO: document available FTP servers -->
@@ -131,8 +131,8 @@ Depending on your available ressources in CPU/RAM vs. bandwidth, run:
 * Or, if you have more available bandwidth than CPU/RAM:
 
   ```bash
-  sudo docker-compose run --rm musicbrainz /fetch-dump.sh search
-  sudo docker-compose run --rm search /load-search-indexes.sh
+  sudo docker-compose run --rm musicbrainz fetch-dump.sh search
+  sudo docker-compose run --rm search load-search-indexes.sh
   ```
 
   (This option downloads 28GB of Zstandard-compressed archives from FTP.)
@@ -185,7 +185,7 @@ sudo docker-compose up -d
 Run replication script once to catch up with latest database updates:
 
 ```bash
-sudo docker-compose exec musicbrainz /replication.sh &
+sudo docker-compose exec musicbrainz replication.sh &
 sudo docker-compose exec musicbrainz /usr/bin/tail -f slave.log
 ```
 
@@ -317,7 +317,7 @@ git clone --branch mbvm-38-dev https://github.com/metabrainz/musicbrainz-docker.
 cd musicbrainz-docker
 admin/configure add musicbrainz-standalone
 sudo docker-compose build
-sudo docker-compose run --rm musicbrainz /createdb.sh -sample -fetch
+sudo docker-compose run --rm musicbrainz createdb.sh -sample -fetch
 sudo docker-compose up -d
 ```
 
@@ -343,7 +343,7 @@ cd musicbrainz-docker
 echo MUSICBRAINZ_SERVER_LOCAL_ROOT="$MUSICBRAINZ_SERVER_LOCAL_ROOT" >> .env
 admin/configure add musicbrainz-dev
 sudo docker-compose up -d
-sudo docker-compose run --rm musicbrainz /createdb.sh -sample -fetch
+sudo docker-compose run --rm musicbrainz createdb.sh -sample -fetch
 ```
 
 The four differences are:
@@ -397,11 +397,11 @@ There are two directories with helper scripts:
 If you need to recreate the database, you will need to enter the
 postgres password set in [postgres.env](default/postgres.env):
 
-* `sudo docker-compose run --rm musicbrainz /recreatedb.sh`
+* `sudo docker-compose run --rm musicbrainz recreatedb.sh`
 
 or to fetch new data dumps before recreating the database:
 
-* `sudo docker-compose run --rm musicbrainz /recreatedb.sh -fetch`
+* `sudo docker-compose run --rm musicbrainz recreatedb.sh -fetch`
 
 ### Recreate database with indexed search
 
@@ -410,10 +410,10 @@ If you need to recreate the database with indexed search,
 ```bash
 admin/configure rm replication-cron # if replication is enabled
 sudo docker-compose stop
-sudo docker-compose run --rm musicbrainz /fetch-dump.sh both
-sudo docker-compose run --rm mq /purge-queues.sh
-sudo docker-compose run --rm search /load-search-indexes.sh --force
-sudo docker-compose run --rm musicbrainz /recreatedb.sh
+sudo docker-compose run --rm musicbrainz fetch-dump.sh both
+sudo docker-compose run --rm mq purge-queues.sh
+sudo docker-compose run --rm search load-search-indexes.sh --force
+sudo docker-compose run --rm musicbrainz recreatedb.sh
 sudo docker-compose up -d
 admin/setup-amqp-triggers clean
 admin/setup-amqp-triggers install
@@ -424,11 +424,11 @@ sudo docker-compose up -d
  you will need to enter the
 postgres password set in [postgres.env](default/postgres.env):
 
-* `sudo docker-compose run --rm musicbrainz /recreatedb.sh`
+* `sudo docker-compose run --rm musicbrainz recreatedb.sh`
 
 or to fetch new data dumps before recreating the database:
 
-* `sudo docker-compose run --rm musicbrainz /recreatedb.sh -fetch`
+* `sudo docker-compose run --rm musicbrainz recreatedb.sh -fetch`
 
 ## Update (after v1.0.0)
 

--- a/admin/setup-amqp-triggers
+++ b/admin/setup-amqp-triggers
@@ -82,7 +82,7 @@ case "$1" in
     musicbrainz_container_id="$($DOCKER_COMPOSE_CMD ps -q musicbrainz)"
     $DOCKER_CMD cp "$LOCAL_TRIGGERS_DIR" "$musicbrainz_container_id":"$REMOTE_TRIGGERS_DIR"
 
-    $DOCKER_COMPOSE_CMD exec musicbrainz /indexer-triggers.sh "$REMOTE_TRIGGERS_DIR" create
+    $DOCKER_COMPOSE_CMD exec musicbrainz indexer-triggers.sh "$REMOTE_TRIGGERS_DIR" create
 
     rm -fr "$LOCAL_TRIGGERS_DIR"
     ;;
@@ -103,7 +103,7 @@ case "$1" in
 
     echo "Uninstalling indexer triggers ..."
 
-    $DOCKER_COMPOSE_CMD exec musicbrainz /indexer-triggers.sh "$REMOTE_TRIGGERS_DIR" drop
+    $DOCKER_COMPOSE_CMD exec musicbrainz indexer-triggers.sh "$REMOTE_TRIGGERS_DIR" drop
 
     $DOCKER_COMPOSE_CMD exec musicbrainz rm -fr "$REMOTE_TRIGGERS_DIR"
     ;;

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -65,9 +65,9 @@ RUN curl -sSL --retry 5 https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt
 WORKDIR /musicbrainz-server
 
 COPY DBDefs.pm /
-COPY scripts/* /
-RUN cat /snippet.perllocallib.bashrc >> ~/.bashrc \
-    && rm /snippet.perllocallib.bashrc
+COPY scripts/* /usr/local/bin/
+RUN cat /usr/local/bin/snippet.perllocallib.bashrc >> ~/.bashrc \
+    && rm /usr/local/bin/snippet.perllocallib.bashrc
 
 # Postgres user/password would be solely needed to compile tests
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
@@ -83,4 +83,4 @@ ENV MUSICBRAINZ_CATALYST_DEBUG=0 \
     POSTGRES_USER=musicbrainz \
     POSTGRES_PASSWORD=musicbrainz
 
-CMD ["/start.sh"]
+CMD ["start.sh"]

--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -78,7 +78,7 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
     if [[ -n "$WGET_OPTIONS" ]]; then
         FETCH_OPTIONS+=(--wget-options "$WGET_OPTIONS")
     fi
-    /fetch-dump.sh "${FETCH_OPTIONS[@]}"
+    fetch-dump.sh "${FETCH_OPTIONS[@]}"
 fi
 
 if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then

--- a/build/musicbrainz-dev/scripts/fetch-dump.sh
+++ b/build/musicbrainz-dev/scripts/fetch-dump.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+DB_DUMP_DIR=/media/dbdump
+BASE_FTP_URL='ftp://ftp.eu.metabrainz.org/pub/musicbrainz'
+TARGET=''
+WGET_CMD=(wget)
+
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<options>] <target>
+
+Fetch dump files of the MusicBrainz database.
+
+Targets:
+  replica       Fetch latest database's replicated tables only.
+  sample        Fetch latest database's sample only.
+
+Options:
+  --base-ftp-url <url>          Specify URL to MetaBrainz/MusicBrainz FTP directory.
+                                (Default: '$BASE_FTP_URL')
+  --wget-options <wget options> Specify additional options to be passed to wget,
+                                these should be separated with whitespace,
+                                the list should be a single argument
+                                (escape whitespaces if needed).
+
+  -h, --help                    Print this help message.
+EOH
+)
+
+# Parse arguments
+
+while [[ $# -gt 0 ]]
+do
+	case "$1" in
+		replica | sample )
+			if [[ -n $TARGET ]]
+			then
+				echo >&2 "$SCRIPT_NAME: only one target argument can be given"
+				echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+				exit 64 # EX_USAGE
+			fi
+			TARGET=$1
+			;;
+		--base-ftp-url )
+			shift
+			BASE_FTP_URL="$1"
+			;;
+		--wget-options )
+			shift
+			IFS=' ' read -r -a WGET_OPTIONS <<< "$1"
+			WGET_CMD+=("${WGET_OPTIONS[@]}")
+			unset WGET_OPTIONS
+			;;
+		-h | --help )
+			echo "$HELP"
+			exit 0 # EX_OK
+			;;
+		-* )
+			echo >&2 "$SCRIPT_NAME: unrecognized option '$1'"
+			echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+			exit 64 # EX_USAGE
+			;;
+		* )
+			echo >&2 "$SCRIPT_NAME: unrecognized argument '$1'"
+			echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+			exit 64 # EX_USAGE
+			;;
+	esac
+	shift
+done
+
+if [[ -z $TARGET ]]
+then
+	echo >&2 "$SCRIPT_NAME: no dump type has been specified"
+	echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+	exit 64 # EX_USAGE
+fi
+
+# Prepare to fetch database dump
+
+echo "$(date): Fetching database dump..."
+
+rm -rf "${DB_DUMP_DIR:?}"/*
+
+case "$TARGET" in
+	replica )
+		DB_DUMP_REMOTE_DIR=data/fullexport
+		DB_DUMP_FILES=(
+			mbdump.tar.bz2
+			mbdump-cdstubs.tar.bz2
+			mbdump-cover-art-archive.tar.bz2
+			mbdump-derived.tar.bz2
+			mbdump-stats.tar.bz2
+			mbdump-wikidocs.tar.bz2
+		)
+		;;
+	sample )
+		DB_DUMP_REMOTE_DIR=data/sample
+		DB_DUMP_FILES=(
+			mbdump-sample.tar.xz
+		)
+		;;
+esac
+
+"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
+	"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
+DUMP_TIMESTAMP=$(cat /media/dbdump/LATEST)
+
+# Actually fetch database dump
+
+if [[ $TARGET == replica ]]
+then
+	for F in MD5SUMS "${DB_DUMP_FILES[@]}"
+	do
+		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
+			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+	done
+	cd "$DB_DUMP_DIR"
+	for F in "${DB_DUMP_FILES[@]}"
+	do
+		MD5SUM=$(md5sum -b "$F")
+		grep -Fqx "$MD5SUM" MD5SUMS || {
+			echo >&2 "$0: unmatched MD5 checksum: $MD5SUM *$F" &&
+			exit 70 # EX_SOFTWARE
+		}
+	done
+	cd -
+elif [[ $TARGET == sample ]]
+then
+	for F in "${DB_DUMP_FILES[@]}"
+	do
+		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
+			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+	done
+fi
+
+echo "$(date): Done fetching dump files."
+# vi: set noexpandtab softtabstop=0:

--- a/build/musicbrainz-dev/scripts/fetch-dump.sh
+++ b/build/musicbrainz-dev/scripts/fetch-dump.sh
@@ -3,6 +3,7 @@
 set -e -o pipefail -u
 
 DB_DUMP_DIR=/media/dbdump
+SEARCH_DUMP_DIR=/media/searchdump
 BASE_FTP_URL='ftp://ftp.eu.metabrainz.org/pub/musicbrainz'
 TARGET=''
 WGET_CMD=(wget)
@@ -11,11 +12,13 @@ SCRIPT_NAME=$(basename "$0")
 HELP=$(cat <<EOH
 Usage: $SCRIPT_NAME [<options>] <target>
 
-Fetch dump files of the MusicBrainz database.
+Fetch dump files of the MusicBrainz database and/or search indexes.
 
 Targets:
+  both          Fetch latest search dump with replica dump of the same day.
   replica       Fetch latest database's replicated tables only.
   sample        Fetch latest database's sample only.
+  search        Fetch latest search indexes only.
 
 Options:
   --base-ftp-url <url>          Specify URL to MetaBrainz/MusicBrainz FTP directory.
@@ -34,7 +37,7 @@ EOH
 while [[ $# -gt 0 ]]
 do
 	case "$1" in
-		replica | sample )
+		both | replica | sample | search )
 			if [[ -n $TARGET ]]
 			then
 				echo >&2 "$SCRIPT_NAME: only one target argument can be given"
@@ -78,14 +81,36 @@ then
 	exit 64 # EX_USAGE
 fi
 
+# Fetch latest search indexes
+
+if [[ $TARGET =~ ^(both|search)$ ]]
+then
+	echo "$(date): Fetching search indexes dump..."
+	cd "$SEARCH_DUMP_DIR" && find . -delete && cd -
+	"${WGET_CMD[@]}" -nd -nH -P "$SEARCH_DUMP_DIR" \
+		"$BASE_FTP_URL/data/search-indexes/LATEST"
+	DUMP_TIMESTAMP=$(cat /media/searchdump/LATEST)
+	"${WGET_CMD[@]}" -nd -nH -r -P "$SEARCH_DUMP_DIR" \
+		"$BASE_FTP_URL/data/search-indexes/$DUMP_TIMESTAMP/"
+	cd "$SEARCH_DUMP_DIR" && md5sum -c MD5SUMS && cd -
+	if [[ $TARGET == search ]]
+	then
+		echo 'Done fetching search indexes dump'
+		exit 0 # EX_OK
+	fi
+fi
+
 # Prepare to fetch database dump
 
-echo "$(date): Fetching database dump..."
+if [[ $TARGET != search ]]
+then
+	echo "$(date): Fetching database dump..."
 
-rm -rf "${DB_DUMP_DIR:?}"/*
+	rm -rf "${DB_DUMP_DIR:?}"/*
+fi
 
 case "$TARGET" in
-	replica )
+	both | replica )
 		DB_DUMP_REMOTE_DIR=data/fullexport
 		DB_DUMP_FILES=(
 			mbdump.tar.bz2
@@ -104,13 +129,31 @@ case "$TARGET" in
 		;;
 esac
 
-"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
-	"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
-DUMP_TIMESTAMP=$(cat /media/dbdump/LATEST)
+if [[ $TARGET == both ]]
+then
+	# Find latest database dump corresponding to search indexes
+
+	SEARCH_DUMP_DAY="${DUMP_TIMESTAMP/-*}"
+	"${WGET_CMD[@]}" --spider --no-remove-listing -P "$DB_DUMP_DIR" \
+		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR"
+	DUMP_TIMESTAMP=$(
+		grep -E "\\s${SEARCH_DUMP_DAY}-\\d*" "$DB_DUMP_DIR/.listing" \
+			| sed -e 's/\s*$//' -e 's/.*\s//'
+	)
+	rm -f "$DB_DUMP_DIR/.listing"
+	echo "$DUMP_TIMESTAMP" >> "$DB_DUMP_DIR/LATEST-WITH-SEARCH-INDEXES"
+elif [[ $TARGET != search ]]
+then
+	# Just find latest database dump
+
+	"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
+		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
+	DUMP_TIMESTAMP=$(cat /media/dbdump/LATEST)
+fi
 
 # Actually fetch database dump
 
-if [[ $TARGET == replica ]]
+if [[ $TARGET =~ ^(both|replica)$ ]]
 then
 	for F in MD5SUMS "${DB_DUMP_FILES[@]}"
 	do

--- a/build/musicbrainz-dev/scripts/recreatedb.sh
+++ b/build/musicbrainz-dev/scripts/recreatedb.sh
@@ -2,4 +2,4 @@
 
 eval "$(perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}")"
 
-psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; /createdb.sh "$@"
+psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; createdb.sh "$@"

--- a/build/musicbrainz-dev/scripts/start.sh
+++ b/build/musicbrainz-dev/scripts/start.sh
@@ -34,5 +34,5 @@ yarn
 
 dockerize -wait tcp://db:5432 -timeout 60s -wait tcp://mq:5672 -timeout 60s -wait tcp://redis:6379 -timeout 60s ./script/compile_resources.sh
 
-/start_mb_renderer.pl
+start_mb_renderer.pl
 start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --nproc 1 --pid fcgi.pid

--- a/build/musicbrainz-dev/scripts/start_mb_renderer.pl
+++ b/build/musicbrainz-dev/scripts/start_mb_renderer.pl
@@ -2,8 +2,7 @@
 
 use strict;
 use warnings;
-use FindBin;
-use lib "$FindBin::Bin/musicbrainz-server/lib";
+use lib "/musicbrainz-server/lib";
 use DBDefs;
 
 my $socket = DBDefs->RENDERER_SOCKET;

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -82,7 +82,7 @@ RUN eval "$(perl -Mlocal::lib)" \
     && rm -rf /root/.cpan* /root/perl5/man/
 
 COPY DBDefs.pm /musicbrainz-server/lib/
-COPY scripts/* /
+COPY scripts/* /usr/local/bin/
 
 # Postgres user/password would be solely needed to compile tests
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
@@ -103,4 +103,4 @@ RUN yarn install \
     && eval "$(perl -Mlocal::lib)" \
     && /musicbrainz-server/script/compile_resources.sh
 
-CMD ["/start.sh"]
+CMD ["start.sh"]

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -78,7 +78,7 @@ if [[ $FETCH_DUMPS == "-fetch" ]]; then
     if [[ -n "$WGET_OPTIONS" ]]; then
         FETCH_OPTIONS+=(--wget-options "$WGET_OPTIONS")
     fi
-    /fetch-dump.sh "${FETCH_OPTIONS[@]}"
+    fetch-dump.sh "${FETCH_OPTIONS[@]}"
 fi
 
 if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then

--- a/build/musicbrainz/scripts/fetch-dump.sh
+++ b/build/musicbrainz/scripts/fetch-dump.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+DB_DUMP_DIR=/media/dbdump
+BASE_FTP_URL='ftp://ftp.eu.metabrainz.org/pub/musicbrainz'
+TARGET=''
+WGET_CMD=(wget)
+
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<options>] <target>
+
+Fetch dump files of the MusicBrainz database.
+
+Targets:
+  replica       Fetch latest database's replicated tables only.
+  sample        Fetch latest database's sample only.
+
+Options:
+  --base-ftp-url <url>          Specify URL to MetaBrainz/MusicBrainz FTP directory.
+                                (Default: '$BASE_FTP_URL')
+  --wget-options <wget options> Specify additional options to be passed to wget,
+                                these should be separated with whitespace,
+                                the list should be a single argument
+                                (escape whitespaces if needed).
+
+  -h, --help                    Print this help message.
+EOH
+)
+
+# Parse arguments
+
+while [[ $# -gt 0 ]]
+do
+	case "$1" in
+		replica | sample )
+			if [[ -n $TARGET ]]
+			then
+				echo >&2 "$SCRIPT_NAME: only one target argument can be given"
+				echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+				exit 64 # EX_USAGE
+			fi
+			TARGET=$1
+			;;
+		--base-ftp-url )
+			shift
+			BASE_FTP_URL="$1"
+			;;
+		--wget-options )
+			shift
+			IFS=' ' read -r -a WGET_OPTIONS <<< "$1"
+			WGET_CMD+=("${WGET_OPTIONS[@]}")
+			unset WGET_OPTIONS
+			;;
+		-h | --help )
+			echo "$HELP"
+			exit 0 # EX_OK
+			;;
+		-* )
+			echo >&2 "$SCRIPT_NAME: unrecognized option '$1'"
+			echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+			exit 64 # EX_USAGE
+			;;
+		* )
+			echo >&2 "$SCRIPT_NAME: unrecognized argument '$1'"
+			echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+			exit 64 # EX_USAGE
+			;;
+	esac
+	shift
+done
+
+if [[ -z $TARGET ]]
+then
+	echo >&2 "$SCRIPT_NAME: no dump type has been specified"
+	echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+	exit 64 # EX_USAGE
+fi
+
+# Prepare to fetch database dump
+
+echo "$(date): Fetching database dump..."
+
+rm -rf "${DB_DUMP_DIR:?}"/*
+
+case "$TARGET" in
+	replica )
+		DB_DUMP_REMOTE_DIR=data/fullexport
+		DB_DUMP_FILES=(
+			mbdump.tar.bz2
+			mbdump-cdstubs.tar.bz2
+			mbdump-cover-art-archive.tar.bz2
+			mbdump-derived.tar.bz2
+			mbdump-stats.tar.bz2
+			mbdump-wikidocs.tar.bz2
+		)
+		;;
+	sample )
+		DB_DUMP_REMOTE_DIR=data/sample
+		DB_DUMP_FILES=(
+			mbdump-sample.tar.xz
+		)
+		;;
+esac
+
+"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
+	"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
+DUMP_TIMESTAMP=$(cat /media/dbdump/LATEST)
+
+# Actually fetch database dump
+
+if [[ $TARGET == replica ]]
+then
+	for F in MD5SUMS "${DB_DUMP_FILES[@]}"
+	do
+		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
+			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+	done
+	cd "$DB_DUMP_DIR"
+	for F in "${DB_DUMP_FILES[@]}"
+	do
+		MD5SUM=$(md5sum -b "$F")
+		grep -Fqx "$MD5SUM" MD5SUMS || {
+			echo >&2 "$0: unmatched MD5 checksum: $MD5SUM *$F" &&
+			exit 70 # EX_SOFTWARE
+		}
+	done
+	cd -
+elif [[ $TARGET == sample ]]
+then
+	for F in "${DB_DUMP_FILES[@]}"
+	do
+		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
+			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+	done
+fi
+
+echo "$(date): Done fetching dump files."
+# vi: set noexpandtab softtabstop=0:

--- a/build/musicbrainz/scripts/fetch-dump.sh
+++ b/build/musicbrainz/scripts/fetch-dump.sh
@@ -3,6 +3,7 @@
 set -e -o pipefail -u
 
 DB_DUMP_DIR=/media/dbdump
+SEARCH_DUMP_DIR=/media/searchdump
 BASE_FTP_URL='ftp://ftp.eu.metabrainz.org/pub/musicbrainz'
 TARGET=''
 WGET_CMD=(wget)
@@ -11,11 +12,13 @@ SCRIPT_NAME=$(basename "$0")
 HELP=$(cat <<EOH
 Usage: $SCRIPT_NAME [<options>] <target>
 
-Fetch dump files of the MusicBrainz database.
+Fetch dump files of the MusicBrainz database and/or search indexes.
 
 Targets:
+  both          Fetch latest search dump with replica dump of the same day.
   replica       Fetch latest database's replicated tables only.
   sample        Fetch latest database's sample only.
+  search        Fetch latest search indexes only.
 
 Options:
   --base-ftp-url <url>          Specify URL to MetaBrainz/MusicBrainz FTP directory.
@@ -34,7 +37,7 @@ EOH
 while [[ $# -gt 0 ]]
 do
 	case "$1" in
-		replica | sample )
+		both | replica | sample | search )
 			if [[ -n $TARGET ]]
 			then
 				echo >&2 "$SCRIPT_NAME: only one target argument can be given"
@@ -78,14 +81,36 @@ then
 	exit 64 # EX_USAGE
 fi
 
+# Fetch latest search indexes
+
+if [[ $TARGET =~ ^(both|search)$ ]]
+then
+	echo "$(date): Fetching search indexes dump..."
+	cd "$SEARCH_DUMP_DIR" && find . -delete && cd -
+	"${WGET_CMD[@]}" -nd -nH -P "$SEARCH_DUMP_DIR" \
+		"$BASE_FTP_URL/data/search-indexes/LATEST"
+	DUMP_TIMESTAMP=$(cat /media/searchdump/LATEST)
+	"${WGET_CMD[@]}" -nd -nH -r -P "$SEARCH_DUMP_DIR" \
+		"$BASE_FTP_URL/data/search-indexes/$DUMP_TIMESTAMP/"
+	cd "$SEARCH_DUMP_DIR" && md5sum -c MD5SUMS && cd -
+	if [[ $TARGET == search ]]
+	then
+		echo 'Done fetching search indexes dump'
+		exit 0 # EX_OK
+	fi
+fi
+
 # Prepare to fetch database dump
 
-echo "$(date): Fetching database dump..."
+if [[ $TARGET != search ]]
+then
+	echo "$(date): Fetching database dump..."
 
-rm -rf "${DB_DUMP_DIR:?}"/*
+	rm -rf "${DB_DUMP_DIR:?}"/*
+fi
 
 case "$TARGET" in
-	replica )
+	both | replica )
 		DB_DUMP_REMOTE_DIR=data/fullexport
 		DB_DUMP_FILES=(
 			mbdump.tar.bz2
@@ -104,13 +129,31 @@ case "$TARGET" in
 		;;
 esac
 
-"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
-	"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
-DUMP_TIMESTAMP=$(cat /media/dbdump/LATEST)
+if [[ $TARGET == both ]]
+then
+	# Find latest database dump corresponding to search indexes
+
+	SEARCH_DUMP_DAY="${DUMP_TIMESTAMP/-*}"
+	"${WGET_CMD[@]}" --spider --no-remove-listing -P "$DB_DUMP_DIR" \
+		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR"
+	DUMP_TIMESTAMP=$(
+		grep -E "\\s${SEARCH_DUMP_DAY}-\\d*" "$DB_DUMP_DIR/.listing" \
+			| sed -e 's/\s*$//' -e 's/.*\s//'
+	)
+	rm -f "$DB_DUMP_DIR/.listing"
+	echo "$DUMP_TIMESTAMP" >> "$DB_DUMP_DIR/LATEST-WITH-SEARCH-INDEXES"
+elif [[ $TARGET != search ]]
+then
+	# Just find latest database dump
+
+	"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
+		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
+	DUMP_TIMESTAMP=$(cat /media/dbdump/LATEST)
+fi
 
 # Actually fetch database dump
 
-if [[ $TARGET == replica ]]
+if [[ $TARGET =~ ^(both|replica)$ ]]
 then
 	for F in MD5SUMS "${DB_DUMP_FILES[@]}"
 	do

--- a/build/musicbrainz/scripts/recreatedb.sh
+++ b/build/musicbrainz/scripts/recreatedb.sh
@@ -2,4 +2,4 @@
 
 eval "$(perl -Mlocal::lib)"
 
-psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; /createdb.sh "$@"
+psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; createdb.sh "$@"

--- a/build/musicbrainz/scripts/start.sh
+++ b/build/musicbrainz/scripts/start.sh
@@ -14,7 +14,7 @@ then
   /musicbrainz-server/script/compile_resources.sh
 fi
 
-dockerize -wait tcp://db:5432 -timeout 60s -wait tcp://mq:5672 -timeout 60s -wait tcp://redis:6379 -timeout 60s /start_mb_renderer.pl
+dockerize -wait tcp://db:5432 -timeout 60s -wait tcp://mq:5672 -timeout 60s -wait tcp://redis:6379 -timeout 60s start_mb_renderer.pl
 
 if [ -f /crons.conf -a -s /crons.conf ]
 then

--- a/build/musicbrainz/scripts/start_mb_renderer.pl
+++ b/build/musicbrainz/scripts/start_mb_renderer.pl
@@ -2,8 +2,7 @@
 
 use strict;
 use warnings;
-use FindBin;
-use lib "$FindBin::Bin/musicbrainz-server/lib";
+use lib "/musicbrainz-server/lib";
 use DBDefs;
 
 my $socket = DBDefs->RENDERER_SOCKET;

--- a/build/solr/Dockerfile
+++ b/build/solr/Dockerfile
@@ -1,0 +1,1 @@
+FROM metabrainz/mb-solr:3.1.1

--- a/build/solr/Dockerfile
+++ b/build/solr/Dockerfile
@@ -1,4 +1,4 @@
 ARG MB_SOLR_VERSION=3.1.3
 FROM metabrainz/mb-solr:${MB_SOLR_VERSION}
 
-COPY [ "scripts/*", "/" ]
+COPY [ "scripts/*", "/usr/local/bin/" ]

--- a/build/solr/Dockerfile
+++ b/build/solr/Dockerfile
@@ -1,1 +1,2 @@
-FROM metabrainz/mb-solr:3.1.1
+ARG MB_SOLR_VERSION=3.1.1
+FROM metabrainz/mb-solr:${MB_SOLR_VERSION}

--- a/build/solr/Dockerfile
+++ b/build/solr/Dockerfile
@@ -1,2 +1,4 @@
-ARG MB_SOLR_VERSION=3.1.1
+ARG MB_SOLR_VERSION=3.1.3
 FROM metabrainz/mb-solr:${MB_SOLR_VERSION}
+
+COPY [ "scripts/*", "/" ]

--- a/build/solr/scripts/load-search-indexes.sh
+++ b/build/solr/scripts/load-search-indexes.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+DUMP_DIR=/media/searchdump
+DATA_DIR=/opt/solr/server/solr/data
+OVERWRITE_FLAG=0
+
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<options>]
+
+Load MusicBrainz Solr search indexes from fetched dump files.
+
+Options:
+  -f, --force   Delete any existing data before loading search indexes
+  -h, --help    Print this help message
+
+Note:
+  The Docker Compose service 'search' must be stopped beforehand.
+EOH
+)
+
+# Parse arguments
+
+if [[ $# -gt 0 && $1 =~ ^-*h(elp)?$ ]]
+then
+	echo "$HELP"
+	exit 0 # EX_OK
+elif [[ $# -eq 1 && $1 =~ ^-*f(orce)?$ ]]
+then
+	OVERWRITE_FLAG=1
+elif [[ $# -gt 0 ]]
+then
+	echo >&2 "$SCRIPT_NAME: unrecognized arguments"
+	echo >&2 "Try '$SCRIPT_NAME help' for usage."
+	exit 64 # EX_USAGE
+fi
+
+# Check existing Solr data and extract search indexes from dump files
+
+cd "$DUMP_DIR"
+
+for dump_file in *.tar.zst
+do
+	collection=${dump_file/.tar.zst}
+	echo "$(date): Load $collection search index..."
+	if [[ $(find "$DATA_DIR/$collection" -type f 2>/dev/null | wc -c) -ne 0 ]]
+	then
+		if [[ $OVERWRITE_FLAG -eq 1 ]]
+		then
+			find "$DATA_DIR/$collection" -type f -delete
+		else
+			echo >&2 "$SCRIPT_NAME: '$collection' has data already"
+			echo >&2 "To delete it first, add the option '--force'."
+			exit 73 # EX_CANTCREAT
+		fi
+	fi
+	tar -x --zstd -f "$DUMP_DIR/$dump_file" -C "$DATA_DIR"
+done
+
+echo "$(date): Done loading search indexes."
+# vi: set noexpandtab softtabstop=0:

--- a/default/replication.cron
+++ b/default/replication.cron
@@ -1,1 +1,1 @@
-0 3 * * * /replication.sh
+0 3 * * * replication.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - search
 
   search:
-    image: metabrainz/mb-solr:3.1.1
+    build: build/solr
     restart: unless-stopped
     expose:
       - "8983"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,11 @@ services:
       - search
 
   search:
-    build: build/solr
+    build:
+      context: build/solr
+      args:
+        - MB_SOLR_VERSION=${MB_SOLR_VERSION:-3.1.1}
+    image: musicbrainz-docker_search:${MB_SOLR_VERSION:-3.1.1}
     restart: unless-stopped
     expose:
       - "8983"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ volumes:
     driver: local
   dbdump:
     driver: local
+  searchdump:
+    driver: local
 
 services:
   db:
@@ -36,6 +38,7 @@ services:
       - "${MUSICBRAINZ_WEB_SERVER_PORT:-5000}:5000"
     volumes:
       - dbdump:/media/dbdump
+      - searchdump:/media/searchdump
     restart: unless-stopped
     env_file:
       - ./default/postgres.env
@@ -64,13 +67,14 @@ services:
     build:
       context: build/solr
       args:
-        - MB_SOLR_VERSION=${MB_SOLR_VERSION:-3.1.1}
-    image: musicbrainz-docker_search:${MB_SOLR_VERSION:-3.1.1}
+        - MB_SOLR_VERSION=${MB_SOLR_VERSION:-3.1.3}
+    image: musicbrainz-docker_search:${MB_SOLR_VERSION:-3.1.3}
     restart: unless-stopped
     expose:
       - "8983"
     volumes:
       - solrdata:/opt/solr/server/solr/data
+      - searchdump:/media/searchdump
 
   mq:
     build: build/rabbitmq


### PR DESCRIPTION
# Implement MBVM-52

Building search indexes takes way too much time for small slave server.

If you have enough available bandwidth to download ~30GB of archived search indexes, this patch helps with fetching search index dumps from FTP and loading these into MB Solr.

```bash
sudo docker-compose run --rm musicbrainz /fetch-dump.sh search
sudo docker-compose run --rm search /load-search-indexes.sh
```

More options are available for each scripts, documented with `--help` option.