### PR TITLE
Update jetty container

### DIFF
--- a/search-dockerfile/Dockerfile
+++ b/search-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:9.3.10
+FROM jetty:9.3-jre8
 
 LABEL Author="Robert Kaye <rob@metabrainz.org>"
 


### PR DESCRIPTION
The tag [jetty:9.3.10](https://hub.docker.com/layers/jetty/library/jetty/9.3.10/images/sha256-f3275f9870c7ff14b50bd949a3278b667dadb40a581ea13d79f35cba85f0153f?context=explore) with Java 8u102 is from 2016.
`9.3-jre8` instead ist continously being updated and works well for the search.