### PR TITLE
Limit logs size for every service

### DIFF
--- a/compose/musicbrainz-dev.yml
+++ b/compose/musicbrainz-dev.yml
@@ -17,6 +17,11 @@ services:
       - validator
   validator:
     image: validator/validator:20.3.16
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
     restart: unless-stopped
     expose:
       - "8888"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,11 @@ services:
       args:
         - POSTGRES_VERSION=${POSTGRES_VERSION:-9.5}
     image: musicbrainz-docker_db:${POSTGRES_VERSION:-9.5}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     restart: unless-stopped
     env_file:
       - ./default/postgres.env
@@ -34,6 +39,11 @@ services:
       context: build/musicbrainz
       args:
         - POSTGRES_VERSION=${POSTGRES_VERSION:-9.5}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "50"
     ports:
       - "${MUSICBRAINZ_WEB_SERVER_PORT:-5000}:5000"
     volumes:
@@ -56,6 +66,11 @@ services:
     build: build/sir
     env_file:
       - ./default/postgres.env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     volumes:
       - ${SIR_CONFIG_PATH:-./default/indexer.ini}:/code/config.ini
     depends_on:
@@ -69,6 +84,11 @@ services:
       args:
         - MB_SOLR_VERSION=${MB_SOLR_VERSION:-3.1.3}
     image: musicbrainz-docker_search:${MB_SOLR_VERSION:-3.1.3}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     restart: unless-stopped
     expose:
       - "8983"
@@ -78,6 +98,11 @@ services:
 
   mq:
     build: build/rabbitmq
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     restart: unless-stopped
     volumes:
       - mqdata:/var/lib/rabbitmq
@@ -86,6 +111,11 @@ services:
 
   redis:
     image: redis:3-alpine
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
     restart: unless-stopped
     expose:
       - "6379"


### PR DESCRIPTION
By default, logs can grow indefinitely in Docker Compose.

This patch prevents this by setting conservative limits:
* The service 'musicbrainz' is allowed 2.5GB of logs, provided that this service is exposed by default.
* Each other service is allowed 100MB of logs.

In development setup, additional services have limits too:
* The service 'validator' is allowed 2MB of logs

Reference: https://docs.docker.com/compose/compose-file/#logging

It should solve disk usage issue in https://github.com/metabrainz/musicbrainz-docker/issues/135.