### PR TITLE
Add support for displaying a map of area's places

### DIFF
--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -396,6 +396,16 @@ sub DATASTORE_REDIS_ARGS {
 # sub COVER_ART_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf("//%s.s3.us.archive.org/", shift) };
 # sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { "//coverartarchive.org" };
 
+# mapbox private access token must be set to display area/place map
+# sub MAPBOX_MAP_ID { 'mapbox.streets' }
+sub MAPBOX_ACCESS_TOKEN {
+    my $file = '/run/secrets/mapbox_access_token';
+    open(my $fh, '<', $file) or return '';
+    chomp(my $token = <$fh> || '');
+    close $fh;
+    return $token;
+}
+
 # Disallow OAuth2 requests over plain HTTP
 # sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER }
 

--- a/build/musicbrainz/DBDefs.pm
+++ b/build/musicbrainz/DBDefs.pm
@@ -383,6 +383,16 @@ sub DATASTORE_REDIS_ARGS {
 # sub COVER_ART_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf("//%s.s3.us.archive.org/", shift) };
 # sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { "//coverartarchive.org" };
 
+# mapbox private access token must be set to display area/place map
+# sub MAPBOX_MAP_ID { 'mapbox.streets' }
+sub MAPBOX_ACCESS_TOKEN {
+    my $file = '/run/secrets/mapbox_access_token';
+    open(my $fh, '<', $file) or return '';
+    chomp(my $token = <$fh> || '');
+    close $fh;
+    return $token;
+}
+
 # Disallow OAuth2 requests over plain HTTP
 # sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER }
 

--- a/compose/mapbox-token.yml
+++ b/compose/mapbox-token.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+# Description: Grant access to Mapbox access token for area/place maps display
+
+services:
+  musicbrainz:
+    secrets:
+      - mapbox_access_token
+
+secrets:
+  mapbox_access_token:
+    file: ${MAPBOX_ACCESS_TOKEN_PATH:-local/secrets/mapbox_access_token}


### PR DESCRIPTION
Allow to set an access token to MapBox API via Docker secrets.
This token will be used to display a map of places in a given area.

e.g. `/area/12c3b82e-fcab-4219-9bd5-792089d8280e/places`