### PR TITLE
Allow to modify memory settings for Postgres and Solr and bump to 2GB each by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,36 @@ admin/configure add publishing-all-ports
 sudo docker-compose up -d
 ```
 
+#### Modify memory settings
+
+To modify memory settings for `db` and `search` services,
+create a file `local/compose/memory-settings.yml` as follows:
+
+```yaml
+version: '3.1'
+
+# Description: Customize memory settings
+
+services:
+  db:
+    command: postgres -c "shared_buffers=4GB" -c "shared_preload_libraries=pg_amqp.so"
+  search:
+    environment:
+      - SOLR_HEAP=4g
+```
+
+See [`postgres`](https://www.postgresql.org/docs/current/app-postgres.html)
+for more configuration parameters and options to pass to `db` service,
+and [`solr.in.sh`](https://github.com/apache/lucene-solr/blob/releases/lucene-solr/7.7.2/solr/bin/solr.in.sh)
+for more environment variables to pass to `search` service,
+
+Then enable it by running:
+
+```bash
+admin/configure add local/compose/memory-settings.yml
+sudo docker-compose up -d
+```
+
 ## Test setup
 
 If you just need a small server with sample data to test your own SQL

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ sudo docker-compose build
 
 ### Create database
 
+:gear: Postgres shared buffers are set to 2GB by default.
+Before running this step, you should consider [modifying your memory
+settings](#modify-memory-settings) in order to give your database a
+sufficient amount of ram, otherwise your database could run very slowly.
+
 Download latest full data dumps and create the database with:
 
 ```bash
@@ -123,6 +128,11 @@ Depending on your available ressources in CPU/RAM vs. bandwidth, run:
   ```bash
   sudo docker-compose exec indexer python -m sir reindex
   ```
+
+  :gear: Java heap for Solr is set to 2GB by default.
+  Before running this step, you should consider [modifying your memory
+  settings](#modify-memory-settings) in order to give your search server a
+  sufficient amount of ram, otherwise your search server could run very slowly.
 
   (This option is known to take 4½ hours with 16 CPU threads and 16 GB RAM.)
 
@@ -329,7 +339,11 @@ sudo docker-compose up -d
 
 #### Modify memory settings
 
-To modify memory settings for `db` and `search` services,
+By default, each of `db` and `search` services have about 2GB of RAM.
+You may want to set more or less memory for any of these services,
+depending on your available resources or on your priorities.
+
+For example, to set 4GB to each of `db` and `search` services,
 create a file `local/compose/memory-settings.yml` as follows:
 
 ```yaml

--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -35,7 +35,3 @@ RUN git clone https://github.com/metabrainz/postgresql-musicbrainz-unaccent.git 
     && make \
     && make install \
     && rm -R /tmp/*
-
-WORKDIR /
-
-COPY set-config.sh /docker-entrypoint-initdb.d

--- a/build/postgres/set-config.sh
+++ b/build/postgres/set-config.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-echo "listen_addresses='*'" >> /var/lib/postgresql/data/postgresql.conf
-echo "shared_buffers = 512MB" >> /var/lib/postgresql/data/postgresql.conf
-echo "shared_preload_libraries = 'pg_amqp.so'" >> /var/lib/postgresql/data/postgresql.conf
-
-exec /docker-entrypoint.sh 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,8 @@ services:
         max-size: "10m"
         max-file: "10"
     restart: unless-stopped
+    environment:
+      - SOLR_HEAP=2g
     expose:
       - "8983"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
         max-size: "10m"
         max-file: "10"
     restart: unless-stopped
+    command: postgres -c "shared_buffers=2048MB" -c "shared_preload_libraries=pg_amqp.so"
     env_file:
       - ./default/postgres.env
     volumes:


### PR DESCRIPTION
The two additional configuration parameters for Postgres were hard-coded in a script installed in the Docker image for the service `db`. It was not easy to change `shared_buffers`’ value to meet meet resources and satisfy needs.

This patch drops the script and set configuration parameters from the `command` defined for the `db` service. It allows to change these values without having to rebuild images, and to add any other configuration parameter or option: just override `command` in a local compose file.

It also increases the value for `shared_buffers` to `2048MB` by default, which is more suitable when running a mirror to speed web service up. It does the same with the Java heap for Solr.

Finally, it documents these new defaults in installation steps and recommends to adjust memory settings to address speed concerns, with a full example of creating a local compose override file.

References:
* https://hub.docker.com/_/postgres/
* https://www.postgresql.org/docs/9.5/app-postgres.html
* https://github.com/apache/lucene-solr/blob/releases/lucene-solr/7.7.2/solr/bin/solr.in.sh/