### PR TITLE
Set SHM size to 2 GB for database container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     command: postgres -c "shared_buffers=2048MB" -c "shared_preload_libraries=pg_amqp.so"
     env_file:
       - ./default/postgres.env
+    shm_size: "2GB"
     volumes:
       - pgdata:/var/lib/postgresql/data
     expose:


### PR DESCRIPTION
## Problem

Default SHM size in Docker is 64MB while new Postgres 10+ uses `/dev/shm` in order to handle additional parallelism in query execution. It makes the database to throw error "could not resize shared memory segment".

## Solution

This patch bumps the allowed SHM size for the database up to 2 GB which is more than enough for a mirror and provisions to handle large queries.
