### PR TITLE
Add entrypoint script to musicbrainz docker image

### DIFF
--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -95,13 +95,15 @@ WORKDIR /musicbrainz-server
 COPY DBDefs.pm /
 COPY scripts/* /usr/local/bin/
 RUN cat /usr/local/bin/snippet.perllocallib.bashrc >> ~/.bashrc \
-    && rm /usr/local/bin/snippet.perllocallib.bashrc
+    && rm /usr/local/bin/snippet.perllocallib.bashrc \
+    && ln -s /usr/local/bin/docker-entrypoint.sh /
 
 # Postgres user/password would be solely needed to compile tests
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
 ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
 
-ENV MUSICBRAINZ_CATALYST_DEBUG=0 \
+ENV BASH_ENV=/noninteractive.bash_env \
+    MUSICBRAINZ_CATALYST_DEBUG=0 \
     MUSICBRAINZ_DEVELOPMENT_SERVER=1 \
     MUSICBRAINZ_SEARCH_SERVER=search:8983/solr \
     MUSICBRAINZ_STANDALONE_SERVER=1 \
@@ -112,4 +114,5 @@ ENV MUSICBRAINZ_CATALYST_DEBUG=0 \
     POSTGRES_USER=musicbrainz \
     POSTGRES_PASSWORD=musicbrainz
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start.sh"]

--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-set -e -o pipefail
-
-# liblocal-lib-perl < 2.000019 generates commands using unset variable
-eval "$(perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}")"
-
-set -u
+set -e -o pipefail -u
 
 FTP_MB=ftp://ftp.eu.metabrainz.org/pub/musicbrainz
 IMPORT="fullexport"

--- a/build/musicbrainz-dev/scripts/docker-entrypoint.sh
+++ b/build/musicbrainz-dev/scripts/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# liblocal-lib-perl < 2.000019 generates commands using unset variable
+eval "$(perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB:?}")"
+
+set -u
+
+mkdir -p "${PERL_CPANM_HOME}" "${PERL_LOCAL_LIB_ROOT}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# shellcheck disable=SC2016
+declare -p \
+  | grep -P '^declare -x (?!(?:BASH_ENV|HOME|LESS_CLOSE|LESS_OPEN|LS_COLORS|OLDPWD|PWD|SHELL|SHLVL|TERM)=)' \
+  | sed 's/^\(declare -x \)\([^=]*\)=\(.*\)$/\1\2=${\2-\3}/' \
+  | sed 's/^\(declare -x PATH\)=\${PATH-\(.*\)}$/\1=\2/' \
+  > /noninteractive.bash_env
+
+# shellcheck disable=SC2016
+echo '[[ -n ${BASH_ENV+set} ]] && unset BASH_ENV' \
+  >> /noninteractive.bash_env
+
+unset BASH_ENV
+
+exec "$@"

--- a/build/musicbrainz-dev/scripts/indexer-triggers.sh
+++ b/build/musicbrainz-dev/scripts/indexer-triggers.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-set -e
-
-# liblocal-lib-perl < 2.000019 generates commands using unset variable
-eval "$(perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}")"
-
-set -u
+set -e -u
 
 HELP="Usage: $0 INDEXER_SQL_DIR <create|drop>"
 

--- a/build/musicbrainz-dev/scripts/recreatedb.sh
+++ b/build/musicbrainz-dev/scripts/recreatedb.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-eval "$(perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}")"
-
 psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; createdb.sh "$@"

--- a/build/musicbrainz-dev/scripts/replication.sh
+++ b/build/musicbrainz-dev/scripts/replication.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-eval "$(perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}")"
-
-export POSTGRES_USER=${POSTGRES_USER:-musicbrainz}
-export POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-musicbrainz}
-
-/bin/bash /musicbrainz-server/admin/cron/slave.sh
+exec /musicbrainz-server/admin/cron/slave.sh

--- a/build/musicbrainz-dev/scripts/start.sh
+++ b/build/musicbrainz-dev/scripts/start.sh
@@ -1,13 +1,6 @@
-#!/bin/sh
-set -e
+#!/bin/bash
 
-# liblocal-lib-perl < 2.000019 generates commands using unset variable
-eval "$(perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}")"
-
-set -u
-
-mkdir -p "${MUSICBRAINZ_PERL_LOCAL_LIB}"
-mkdir -p "${PERL_CPANM_HOME}"
+set -e -u
 
 cd /musicbrainz-server
 

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -112,6 +112,9 @@ RUN eval "$(perl -Mlocal::lib)" \
 
 COPY DBDefs.pm /musicbrainz-server/lib/
 COPY scripts/* /usr/local/bin/
+RUN cat /usr/local/bin/snippet.perllocallib.bashrc >> ~/.bashrc \
+    && rm /usr/local/bin/snippet.perllocallib.bashrc \
+    && ln -s /usr/local/bin/docker-entrypoint.sh /
 
 # Postgres user/password would be solely needed to compile tests
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
@@ -133,4 +136,5 @@ RUN yarn install \
     && eval "$(perl -Mlocal::lib)" \
     && /musicbrainz-server/script/compile_resources.sh
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start.sh"]

--- a/build/musicbrainz/README.md
+++ b/build/musicbrainz/README.md
@@ -1,2 +1,0 @@
-[![](https://images.microbadger.com/badges/version/jsturgis/musicbrainz.svg)](http://microbadger.com/images/jsturgis/musicbrainz "Get your own version badge on microbadger.com")
-[![](https://images.microbadger.com/badges/image/jsturgis/musicbrainz.svg)](http://microbadger.com/images/jsturgis/musicbrainz "Get your own image badge on microbadger.com")

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-set -e -o pipefail
-
-# liblocal-lib-perl < 2.000019 generates commands using unset variable
-eval "$(perl -Mlocal::lib)"
-
-set -u
+set -e -o pipefail -u
 
 FTP_MB=ftp://ftp.eu.metabrainz.org/pub/musicbrainz
 IMPORT="fullexport"

--- a/build/musicbrainz/scripts/docker-entrypoint.sh
+++ b/build/musicbrainz/scripts/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# liblocal-lib-perl < 2.000019 generates commands using unset variable
+eval "$(perl -Mlocal::lib)"
+
+set -u
+
+export DEBIAN_FRONTEND=noninteractive
+
+# shellcheck disable=SC2016
+declare -p \
+  | grep -P '^declare -x (?!(?:BASH_ENV|HOME|LESS_CLOSE|LESS_OPEN|LS_COLORS|OLDPWD|PWD|SHELL|SHLVL|TERM)=)' \
+  | sed 's/^\(declare -x \)\([^=]*\)=\(.*\)$/\1\2=${\2-\3}/' \
+  | sed 's/^\(declare -x PATH\)=\${PATH-\(.*\)}$/\1=\2/' \
+  > /noninteractive.bash_env
+
+# shellcheck disable=SC2016
+echo '[[ -n ${BASH_ENV+set} ]] && unset BASH_ENV' \
+  >> /noninteractive.bash_env
+
+unset BASH_ENV
+
+exec "$@"

--- a/build/musicbrainz/scripts/indexer-triggers.sh
+++ b/build/musicbrainz/scripts/indexer-triggers.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-set -e
-
-# liblocal-lib-perl < 2.000019 generates commands using unset variable
-eval "$(perl -Mlocal::lib)"
-
-set -u
+set -e -u
 
 HELP="Usage: $0 INDEXER_SQL_DIR <create|drop>"
 

--- a/build/musicbrainz/scripts/recreatedb.sh
+++ b/build/musicbrainz/scripts/recreatedb.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-eval "$(perl -Mlocal::lib)"
-
 psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; createdb.sh "$@"

--- a/build/musicbrainz/scripts/replication.sh
+++ b/build/musicbrainz/scripts/replication.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-eval "$(perl -Mlocal::lib)"
-
-export POSTGRES_USER=${POSTGRES_USER:-musicbrainz}
-export POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-musicbrainz}
-
-/bin/bash /musicbrainz-server/admin/cron/slave.sh
+exec /musicbrainz-server/admin/cron/slave.sh

--- a/build/musicbrainz/scripts/snippet.perllocallib.bashrc
+++ b/build/musicbrainz/scripts/snippet.perllocallib.bashrc
@@ -5,7 +5,7 @@
 if [[ $- = *i* ]]; then
     # Enable locally installed Perl modules if not enabled already
     if [[ -z ${PERL_LOCAL_LIB_ROOT+set} ]]; then
-        eval "$(perl -Mlocal::lib="${MUSICBRAINZ_PERL_LOCAL_LIB}")"
+        eval "$(perl -Mlocal::lib)"
     fi
     # Unset BASH_ENV which is for noninteractive scripts only
     if [[ -n ${BASH_ENV+set} ]]; then

--- a/build/musicbrainz/scripts/start.sh
+++ b/build/musicbrainz/scripts/start.sh
@@ -1,11 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
-
-# liblocal-lib-perl < 2.000019 generates commands using unset variable
-eval "$(perl -Mlocal::lib)"
-
-set -u
+set -e -u
 
 if ! grep -q -s \
   "//${MUSICBRAINZ_WEB_SERVER_HOST}:${MUSICBRAINZ_WEB_SERVER_PORT}" \

--- a/default/replication.cron
+++ b/default/replication.cron
@@ -1,1 +1,3 @@
+SHELL=/bin/bash
+BASH_ENV=/noninteractive.bash_env
 0 3 * * * /usr/local/bin/replication.sh


### PR DESCRIPTION
Add an entry point to `musicbrainz` service that defines Perl environment variables and passes additional environment variables to cron jobs.

Fix #168 

See commit message for details.

Notes:
* If you [customized the replication schedule](https://github.com/metabrainz/musicbrainz-docker/tree/v-2020-08-10#customize-replication-schedule), make sure to copy the two variables now defined in `default/replication.cron` to your crontab.
* If you customized entry point or default command for the `musicbrainz` service, make sure to set environment variables accordingly.
