### PR TITLE
MBVM-60: Clean setup-amqp-triggers output

### DIFF
--- a/build/musicbrainz-dev/scripts/indexer-triggers.sh
+++ b/build/musicbrainz-dev/scripts/indexer-triggers.sh
@@ -18,7 +18,9 @@ case "$2" in
   create)
     admin/psql < "$INDEXER_SQL_DIR/CreateFunctions.sql"
     admin/psql < "$INDEXER_SQL_DIR/CreateTriggers.sql"
-    admin/GenerateSQLScripts.pl "$INDEXER_SQL_DIR/"
+    admin/GenerateSQLScripts.pl \
+      -c "CreateFunctions.sql" "CreateTriggers.sql" \
+      "$INDEXER_SQL_DIR/"
     ;;
   drop  )
     admin/psql < "$INDEXER_SQL_DIR/DropTriggers.sql"

--- a/build/musicbrainz/scripts/indexer-triggers.sh
+++ b/build/musicbrainz/scripts/indexer-triggers.sh
@@ -18,7 +18,9 @@ case "$2" in
   create)
     admin/psql < "$INDEXER_SQL_DIR/CreateFunctions.sql"
     admin/psql < "$INDEXER_SQL_DIR/CreateTriggers.sql"
-    admin/GenerateSQLScripts.pl "$INDEXER_SQL_DIR/"
+    admin/GenerateSQLScripts.pl \
+      -c "CreateFunctions.sql" "CreateTriggers.sql" \
+      "$INDEXER_SQL_DIR/"
     ;;
   drop  )
     admin/psql < "$INDEXER_SQL_DIR/DropTriggers.sql"


### PR DESCRIPTION
# Problem

MBVM-60: Output of `setup-amqp-triggers` is misleading and incomplete

# Solution

Use newly added option to `GenerateSQLScripts.pl` for a cleaner output.

# Checklist for author

* [X] Locally tested with https://github.com/metabrainz/musicbrainz-server/pull/1688
* [ ] Get https://github.com/metabrainz/musicbrainz-server/pull/1688 merged
* [ ] Upgrade to the next release of MusicBrainz Server