### PR TITLE
Add build/compose files for SIR development

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,10 @@ Replication is not applicable to test setup.
 
 Required disk space is much lesser than normal setup: 15GB to be safe.
 
+The below sections are optional depending on which service(s) you are coding.
+
+### Local development of MusicBrainz Server
+
 For local development of MusicBrainz Server, you can run the below
 commands instead of following the above [installation](#installation):
 
@@ -436,6 +440,34 @@ sudo docker-compose restart musicbrainz
 [Enable live indexing](#enable-live-indexing) are the same.
 
 Replication is not applicable to development setup.
+
+Simply restart the container when checking out a new branch.
+
+### Local development of Search Index Rebuilder
+
+This is very similar to the above but for Search Index Rebuilder (SIR):
+1. Set the variable `SIR_LOCAL_ROOT` in the `.env` file
+2. Run `admin/configure add sir-dev`
+3. Run `sudo docker-compose up -d`
+
+Notes:
+* It will override any `config.ini` file in your local working copy of SIR.
+* Requirements are being cached and will be updated on container’s startup.
+* See [how to configure SIR in `musicbrainz-docker`](#customize-search-indexer-configuration).
+
+### Local development of MusicBrainz Solr
+
+The situation is quite different for this service as it doesn’t
+depends on any other. Its development rather rely on schema. See
+[mb-solr](https://github.com/metabrainz/mb-solr) and
+[mmd-schema](https://github.com/metabrainz/mmd-schema).
+
+However, other services depend on it, so it is useful to run a local
+version of `mb-solr` in `search` service for integration tests:
+1. Run `build.sh` from your `mb-solr` local working copy to build a
+   an image of `metabrainz/mb-solr` with a custom tag.
+2. Set `MB_SOLR_VERSION` in `.env` to this custom tag.
+3. Run `sudo docker-compose up -d`
 
 ## Helper scripts
 

--- a/build/sir-dev/Dockerfile
+++ b/build/sir-dev/Dockerfile
@@ -1,0 +1,59 @@
+ARG PYTHON_VERSION=2.7
+FROM metabrainz/python:${PYTHON_VERSION}
+
+ARG PYTHON_VERSION
+
+LABEL org.metabrainz.based-on-image="metabrainz/python:${PYTHON_VERSION}"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+#######################
+# From metabrainz/sir #
+#######################
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -qy \
+      build-essential \
+      ca-certificates \
+      cron \
+      git \
+      # TODO: check if this is actually needed
+      libffi-dev \
+      # required for connections of pip packages
+      libssl-dev \
+      # required for psycopg2. Installs without it but links against a wrong .so.
+      libpq-dev \
+      # required for testing search entities
+      libsqlite3-dev \
+      # required by lxml from mb-rngpy
+      libxslt1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+##################
+# Installing sir #
+##################
+
+ARG SIR_VERSION=py27-stage1
+
+LABEL org.metabrainz.sir.version="${SIR_VERSION}"
+
+ARG DOCKERIZE_VERSION=v0.6.1
+RUN curl -sSLO --retry 5 https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+COPY scripts/* /usr/local/bin/
+
+RUN echo Requirements will be installed at run time from entrypoint. \
+    && rm -f /code/config.ini \
+    && touch /etc/consul-template.conf
+
+WORKDIR /code
+
+ENV POSTGRES_USER=musicbrainz
+ENV POSTGRES_PASSWORD=musicbrainz
+ENV PYTHONPATH="/code/venv-musicbrainz-docker/lib/python2.7"
+ENV PATH="/code/venv-musicbrainz-docker/bin:$PATH"
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["my_init"]

--- a/build/sir-dev/scripts/docker-entrypoint.sh
+++ b/build/sir-dev/scripts/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e -u
+
+mkdir -p .cache
+
+pip install \
+  --cache-dir /code/.cache \
+  --disable-pip-version-check \
+  --prefix /code/venv-musicbrainz-docker \
+  -r requirements.txt \
+  -r requirements_dev.txt
+
+dockerize \
+  -wait tcp://db:5432 -timeout 60s \
+  -wait tcp://mq:5672 -timeout 60s \
+  -wait tcp://search:8983 -timeout 60s \
+  sleep 0
+
+exec "$@"

--- a/compose/sir-dev.yml
+++ b/compose/sir-dev.yml
@@ -1,0 +1,16 @@
+version: '3.1'
+
+# Description: Build and run local development copy of SIR
+
+services:
+  indexer:
+    build: build/sir-dev
+    env_file:
+      - ./default/postgres.env
+    volumes:
+      - ${SIR_LOCAL_ROOT:?Missing path of sir working copy}:/code
+      - ${SIR_CONFIG_PATH:-./default/indexer.ini}:/code/config.ini
+    depends_on:
+      - db
+      - mq
+      - search


### PR DESCRIPTION
It is purposed for Search Index Rebuilder (SIR) contributors.

It allows running local development version of SIR by mounting local working copy from `SIR_LOCAL_ROOT` (specified in `.env`) onto `/code` in the container for the `indexer` service.

See https://docs.docker.com/compose/faq/#should-i-include-my-code-with-copyadd-or-a-volume

It also mounts the file from `SIR_CONFIG_PATH` (specified in `.env`) onto `/code/config.ini` in the container for the `indexer` service. Note: This will override any `config.ini` in your local working copy.

New `build/sir-dev/` heavily derives from `build/sir/`.

Python requirements are installed/updated at container’s run time under `$SIR_LOCAL_ROOT/venv-musicbrainz-docker` of the host (mapped to `/code/venv-musicbrainz-docker` in the container), using cache under `SIR_LOCAL_ROOT/.cache` of the host (mapped to `/code/.cache` in the container). Environment variables `PYTHONPATH` and `PATH` are set accordingly.

Last, it uses `dockerize` to wait for other services to be up.