### PR TITLE
MBVM-62: Make MusicBrainz scripts wait for the 'db' service

### DIFF
--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -78,6 +78,7 @@ fi
 
 if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
     echo "found existing dumps"
+    dockerize -wait tcp://db:5432 -timeout 60s sleep 0
 
     mkdir -p $TMP_DIR
     cd /media/dbdump

--- a/build/musicbrainz-dev/scripts/indexer-triggers.sh
+++ b/build/musicbrainz-dev/scripts/indexer-triggers.sh
@@ -12,6 +12,8 @@ fi
 
 INDEXER_SQL_DIR="$1"
 
+dockerize -wait tcp://db:5432 -timeout 60s sleep 0
+
 cd /musicbrainz-server
 
 case "$2" in

--- a/build/musicbrainz-dev/scripts/recreatedb.sh
+++ b/build/musicbrainz-dev/scripts/recreatedb.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -e
+
+dockerize -wait tcp://db:5432 -timeout 60s sleep 0
 psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; createdb.sh "$@"

--- a/build/musicbrainz-dev/scripts/replication.sh
+++ b/build/musicbrainz-dev/scripts/replication.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -e
+
+dockerize -wait tcp://db:5432 -timeout 60s sleep 0
 exec /musicbrainz-server/admin/cron/slave.sh

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -78,6 +78,7 @@ fi
 
 if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
     echo "found existing dumps"
+    dockerize -wait tcp://db:5432 -timeout 60s sleep 0
 
     mkdir -p $TMP_DIR
     cd /media/dbdump

--- a/build/musicbrainz/scripts/indexer-triggers.sh
+++ b/build/musicbrainz/scripts/indexer-triggers.sh
@@ -12,6 +12,8 @@ fi
 
 INDEXER_SQL_DIR="$1"
 
+dockerize -wait tcp://db:5432 -timeout 60s sleep 0
+
 cd /musicbrainz-server
 
 case "$2" in

--- a/build/musicbrainz/scripts/recreatedb.sh
+++ b/build/musicbrainz/scripts/recreatedb.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -e
+
+dockerize -wait tcp://db:5432 -timeout 60s sleep 0
 psql postgres -U musicbrainz -h db -c "DROP DATABASE musicbrainz_db;"; createdb.sh "$@"

--- a/build/musicbrainz/scripts/replication.sh
+++ b/build/musicbrainz/scripts/replication.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -e
+
+dockerize -wait tcp://db:5432 -timeout 60s sleep 0
 exec /musicbrainz-server/admin/cron/slave.sh


### PR DESCRIPTION
# Problem

Fix #170 / MBVM-62: When creating database (or running any script from a fresh container), the `db` service was not always up before the script tried to query it.

# Solution

This patch makes MusicBrainz scripts that require a database connection to wait for the `db` service before trying to open a connection to it.