### PR TITLE
MBVM-65: Drop port numbers 80 and 443 from base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ By default, the web server listens at <http://localhost:5000>
 This can be changed using the two Docker environment variables
 `MUSICBRAINZ_WEB_SERVER_HOST` and `MUSICBRAINZ_WEB_SERVER_PORT`.
 
+If `MUSICBRAINZ_WEB_SERVER_PORT` set to `80` (http), then the
+port number will not appear in the base URL of the web server.
+
+If set to `443` (https), then the port number will not appear either,
+but the a separate reverse proxy is required to handle https correctly.
+
 #### Customize the number of processes for MusicBrainz Server
 
 By default, MusicBrainz Server uses 10 `plackup` processes at once.

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -182,7 +182,12 @@ sub REPLICATION_ACCESS_TOKEN {
 # Additionally you should set the environment variable
 # MUSICBRAINZ_USE_PROXY=1 when using a reverse proxy to make the server
 # aware of it when generating things like the canonical url in catalyst.
-sub WEB_SERVER                { "$ENV{MUSICBRAINZ_WEB_SERVER_HOST}:$ENV{MUSICBRAINZ_WEB_SERVER_PORT}" }
+sub WEB_SERVER {
+    $ENV{MUSICBRAINZ_WEB_SERVER_PORT} == 80 ||
+    $ENV{MUSICBRAINZ_WEB_SERVER_PORT} == 443
+        ? "$ENV{MUSICBRAINZ_WEB_SERVER_HOST}"
+        : "$ENV{MUSICBRAINZ_WEB_SERVER_HOST}:$ENV{MUSICBRAINZ_WEB_SERVER_PORT}"
+}
 # Relevant only if SSL redirects are enabled
 # sub WEB_SERVER_SSL            { "localhost" }
 sub SEARCH_SERVER             { "$ENV{MUSICBRAINZ_SEARCH_SERVER}" }

--- a/build/musicbrainz/DBDefs.pm
+++ b/build/musicbrainz/DBDefs.pm
@@ -169,7 +169,12 @@ sub REPLICATION_ACCESS_TOKEN {
 # Additionally you should set the environment variable
 # MUSICBRAINZ_USE_PROXY=1 when using a reverse proxy to make the server
 # aware of it when generating things like the canonical url in catalyst.
-sub WEB_SERVER                { "$ENV{MUSICBRAINZ_WEB_SERVER_HOST}:$ENV{MUSICBRAINZ_WEB_SERVER_PORT}" }
+sub WEB_SERVER {
+    $ENV{MUSICBRAINZ_WEB_SERVER_PORT} == 80 ||
+    $ENV{MUSICBRAINZ_WEB_SERVER_PORT} == 443
+        ? "$ENV{MUSICBRAINZ_WEB_SERVER_HOST}"
+        : "$ENV{MUSICBRAINZ_WEB_SERVER_HOST}:$ENV{MUSICBRAINZ_WEB_SERVER_PORT}"
+}
 # Relevant only if SSL redirects are enabled
 # sub WEB_SERVER_SSL            { "localhost" }
 sub SEARCH_SERVER             { "$ENV{MUSICBRAINZ_SEARCH_SERVER}" }


### PR DESCRIPTION
# Resolve MBVM-65

Port numbers 80 (default port for http) and 443 (default port for https) are not actually required in URL. This patch drops these from base URL.

Note: An extra reverse proxy for https is needed if port is set to 443.