### PR TITLE
MBVM-66: Fix running createdb.sh in development setup

### DIFF
--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -80,6 +80,8 @@ if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
     echo "found existing dumps"
     dockerize -wait tcp://db:5432 -timeout 60s sleep 0
 
+    update-perl.sh
+
     mkdir -p $TMP_DIR
     cd /media/dbdump
 

--- a/build/musicbrainz-dev/scripts/start.sh
+++ b/build/musicbrainz-dev/scripts/start.sh
@@ -4,24 +4,7 @@ set -e -u
 
 cd /musicbrainz-server
 
-diff /DBDefs.pm lib/DBDefs.pm || cat /DBDefs.pm > lib/DBDefs.pm
-
-cpanm --installdeps --notest --with-develop .
-cpanm --notest \
-  Cache::Memcached::Fast \
-  Cache::Memory \
-  Catalyst::Plugin::Cache::HTTP \
-  Catalyst::Plugin::StackTrace \
-  Digest::MD5::File \
-  File::Slurp \
-  JSON::Any \
-  LWP::Protocol::https \
-  Plack::Handler::Starlet \
-  Plack::Middleware::Debug::Base \
-  Server::Starter \
-  Starlet \
-  Starlet::Server \
-  Term::Size::Any
+update-perl.sh
 
 yarn
 

--- a/build/musicbrainz-dev/scripts/start.sh
+++ b/build/musicbrainz-dev/scripts/start.sh
@@ -6,9 +6,7 @@ cd /musicbrainz-server
 
 update-perl.sh
 
-yarn
-
-dockerize -wait tcp://db:5432 -timeout 60s -wait tcp://mq:5672 -timeout 60s -wait tcp://redis:6379 -timeout 60s ./script/compile_resources.sh
+update-javascript.sh
 
 start_mb_renderer.pl
 start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --nproc ${MUSICBRAINZ_SERVER_PROCESSES} --pid fcgi.pid

--- a/build/musicbrainz-dev/scripts/update-javascript.sh
+++ b/build/musicbrainz-dev/scripts/update-javascript.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -u
+
+cd /musicbrainz-server
+
+yarn
+
+dockerize -wait tcp://db:5432 -timeout 60s -wait tcp://mq:5672 -timeout 60s -wait tcp://redis:6379 -timeout 60s ./script/compile_resources.sh
+

--- a/build/musicbrainz-dev/scripts/update-perl.sh
+++ b/build/musicbrainz-dev/scripts/update-perl.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e -u
+
+cd /musicbrainz-server
+
+diff /DBDefs.pm lib/DBDefs.pm || cat /DBDefs.pm > lib/DBDefs.pm
+
+cpanm --installdeps --notest --with-develop .
+cpanm --notest \
+  Cache::Memcached::Fast \
+  Cache::Memory \
+  Catalyst::Plugin::Cache::HTTP \
+  Catalyst::Plugin::StackTrace \
+  Digest::MD5::File \
+  File::Slurp \
+  JSON::Any \
+  LWP::Protocol::https \
+  Plack::Handler::Starlet \
+  Plack::Middleware::Debug::Base \
+  Server::Starter \
+  Starlet \
+  Starlet::Server \
+  Term::Size::Any


### PR DESCRIPTION
# Fix #161 aka MBVM-66

## Problem
Since the script `createdb.sh` is recommended to be run before any other `musicbrainz` container started, the configuration file `/lib/DBDefs.pm` and Perl dependencies are initially missing.

## Solution
This patch installs or update these when running `createdb.sh` in development setup.