### PR TITLE
Add troubleshooting page for frequent setup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,10 @@ Check [releases](https://github.com/metabrainz/musicbrainz-docker/releases) for 
 
 ## Issues
 
-If anything doesn't work please create an issue with versions info:
+If anything doesn't work, check the [troubleshooting](TROUBLESHOOTING.md) page.
+
+
+If you still don’t have a solution, please create an issue with versions info:
 
 ```bash
 echo MusicBrainz Docker: `git describe --always --broken --dirty --tags` && \

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,52 @@
+# Troubleshooting
+
+## Table of contents
+
+<!-- toc -->
+
+- [InitDb.pl failed on macOS](#initdbpl-failed-on-macos)
+- [Resolving name failed](#resolving-name-failed)
+
+<!-- tocstop -->
+
+## InitDb.pl failed on macOS
+
+When creating the database:
+
+```log
+Wed Feb 24 14:29:01 2021 : Creating indexes ... (CreateIndexes.sql)
+Wed Feb 24 14:29:12 2021 : psql:/musicbrainz-server/admin/sql/CreateIndexes.sql:467: server closed the connection unexpectedly
+Wed Feb 24 14:29:12 2021 : 	This probably means the server terminated abnormally
+Wed Feb 24 14:29:12 2021 : 	before or while processing the request.
+Wed Feb 24 14:29:12 2021 : psql:/musicbrainz-server/admin/sql/CreateIndexes.sql:467: fatal: connection to server was lost
+Error during CreateIndexes.sql at /musicbrainz-server/admin/InitDb.pl line 117.
+Wed Feb 24 14:29:12 2021 : InitDb.pl failed
+```
+
+Solution:
+
+Add more than 2GB memory to containers on macOS.
+
+## Resolving name failed
+
+When building Docker images:
+
+```log
+Err:1 http://security.debian.org/debian-security buster/updates InRelease
+  Temporary failure resolving 'security.debian.org'
+```
+
+Solution:
+
+That can be your `bridge` nework has no default gateway yet.
+That can be checked by running:
+
+```bash
+docker network inspect bridge
+```
+
+In such case, try restarting docker daemon:
+
+```bash
+sudo service docker restart
+```


### PR DESCRIPTION
Two known issues to start with:

* InitDb.pl failed on macOS (when creating the database)
* Resolving name failed (when building Docker images)