### PR TITLE
MBVM-69: Fix persistence of search message queues

### DIFF
--- a/build/rabbitmq/scripts/set-config.sh
+++ b/build/rabbitmq/scripts/set-config.sh
@@ -17,9 +17,28 @@ while :; do
   remaining_time=$(($remaining_time - 1))
 done
 
-rabbitmqctl add_user sir sir
-rabbitmqctl set_user_tags sir management
-rabbitmqctl add_vhost /search-index-rebuilder
-rabbitmqctl set_permissions -p /search-index-rebuilder sir '.*' '.*' '.*'
+if ! (rabbitmqctl list_users \
+  | grep -q '^sir\s')
+then
+  rabbitmqctl add_user sir sir
+fi
+
+if ! (rabbitmqctl list_users \
+  | grep -q '^sir\s\+\[management\]$')
+then
+  rabbitmqctl set_user_tags sir management
+fi
+
+if ! (rabbitmqctl list_vhosts \
+  | grep -q '^/search-index-rebuilder$')
+then
+  rabbitmqctl add_vhost /search-index-rebuilder
+fi
+
+if ! (rabbitmqctl list_permissions -p /search-index-rebuilder \
+  | grep -q '^sir\s\+\.\*\s\+\.\*\s\+\.\*$')
+then
+  rabbitmqctl set_permissions -p /search-index-rebuilder sir '.*' '.*' '.*'
+fi
 
 echo "Done."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,7 @@ services:
 
   mq:
     build: build/rabbitmq
+    hostname: "mq"
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
# Fix MBVM-69: Recreating mq container breaks live indexing

### Problem

Message queues for live indexing were not found after recreating container for `mq` service. This caused live indexing to stop working. A known workaround was to run `amqp_setup` again. This was due to RabbitMQ storing its data under a directory named after the host name which is sets at random on container’s creation.

### Solution

This patch sets hostname to `mq` in new containers for `mq` service.

Also patched the script that sets configuration to check for current settings before doing anything.

### Actions

Deploying this patch requires special steps only if live indexing is on:

1. Stop `musicbrainz` service to stop replication
    ```sh
    sudo docker-compose stop musicbrainz
    ```
   (Or stop `cron` and `replication.sh` if running)

2. Wait for `search.index` queue to become empty
    ```sh
    sudo docker-compose exec mq \
        rabbitmqadmin -u sir -p sir -V /search-index-rebuilder \
            list queues
    ```

3. Recreate container for `mq` service to use the new hostname
    ```sh
    sudo docker-compose up -d mq
    ```

4. Recreate `search` queues
    ```sh
    sudo docker-compose exec indexer python -m sir amqp_setup
    ```

5. Check that `search.index` queue is available (and empty)
    ```sh
    sudo docker-compose exec mq \
        rabbitmqadmin -u sir -p sir -V /search-index-rebuilder \
            list queues
    ```

6. Restart the indexer
    ```sh
    sudo docker-compose restart indexer
    ```

7. Start `musicbrainz` service
    ```sh
    sudo docker-compose start musicbrainz
    ```

   (Or resume replication)