### PR TITLE
Fix unbound variable BASE_FTP_URL in fetch-dump.sh

### DIFF
--- a/build/musicbrainz-dev/scripts/fetch-dump.sh
+++ b/build/musicbrainz-dev/scripts/fetch-dump.sh
@@ -4,7 +4,7 @@ set -e -o pipefail -u
 
 DB_DUMP_DIR=/media/dbdump
 SEARCH_DUMP_DIR=/media/searchdump
-BASE_FTP_MB="$MUSICBRAINZ_BASE_FTP_URL"
+BASE_FTP_URL="$MUSICBRAINZ_BASE_FTP_URL"
 TARGET=''
 WGET_CMD=(wget)
 


### PR DESCRIPTION
Executing `sudo docker-compose run --rm musicbrainz createdb.sh -sample -fetch` under development setup causes error: 
`/usr/local/bin/fetch-dump.sh: line 33: BASE_FTP_URL: unbound variable`

In `build/musicbrainz-dev/scripts/fetch-dump.sh`, `BASE_FTP_MB` seems a typo and should be `BASE_FTP_URL`, this bug was introduced in commit 63c96d0be7ab00e967ed84b9a211c7693969ef58.