### PR TITLE
Document troubleshooting in development setup

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -81,3 +81,29 @@ It will automatically reinstall them all using current Perl version:
 sudo rm -fr "$MUSICBRAINZ_SERVER_LOCAL_ROOT/perl_modules/
 sudo docker-compose restart musicbrainz
 ```
+
+## ImportError: No module named
+
+Using Search Index Rebuilder’s development setup only,
+when `indexer` service doesn’t work as expected,
+and python commands return the following:
+
+```log
+Traceback (most recent call last):
+[...]
+ImportError: No module named [...]
+```
+
+(where the latest `[...]` may be `sqlalchemy` or any other dependency)
+
+Solution:
+
+Remove all installed Python packages and installation cache as follows:
+
+```bash
+sudo docker-compose exec indexer rm -fr /code/.cache /code/venv-musicbrainz-docker
+sudo docker-compose restart indexer
+```
+
+Python packages are downloaded again and installed again when the
+service `indexer` restarts.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -50,3 +50,34 @@ In such case, try restarting docker daemon:
 ```bash
 sudo service docker restart
 ```
+
+## Loadable library and perl binaries are mismatched
+
+Using MusicBrainz server’s development setup only,
+when `musicbrainz` service doesn’t work as expected,
+and after retrieving its logs as follows:
+
+```bash
+sudo docker-compose logs --timestamps musicbrainz
+```
+
+returned logs contain the following error message:
+
+```log
+ListUtil.c: loadable library and perl binaries are mismatched (got handshake key 0xdb00080, needed 0xcd00080)
+```
+
+That means the Perl dependencies have been installed with another
+version of Perl. It happens after the required version of Perl for
+MusicBrainz Server has changed, mostly when switching from/to
+different branches or versions of `musicbrainz-server`.
+
+Solution:
+
+Remove installed Perl dependencies and restart `musicbrainz` service;
+It will automatically reinstall them all using current Perl version:
+
+```bash
+sudo rm -fr "$MUSICBRAINZ_SERVER_LOCAL_ROOT/perl_modules/
+sudo docker-compose restart musicbrainz
+```

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -6,6 +6,8 @@
 
 - [InitDb.pl failed on macOS](#initdbpl-failed-on-macos)
 - [Resolving name failed](#resolving-name-failed)
+- [Loadable library and perl binaries are mismatched](#loadable-library-and-perl-binaries-are-mismatched)
+- [ImportError: No module named](#importerror-no-module-named)
 
 <!-- tocstop -->
 


### PR DESCRIPTION
Add troubleshooting instructions for developers:
* Reinstall Perl dependencies after `loadable library and perl binaries are mismatched` error message occurs in `musicbrainz` logs

## Checklist

* [ ] Run `markdown-toc -i --maxdepth 3 TROUBLESHOOTING.md` again