### PR TITLE
MBVM-75: Enable watch mode for JavaScript and Perl in development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,8 @@ The four differences are:
 2. MusicBrainz Server runs in standalone mode instead of slave mode,
 3. development mode is enabled (but Catalyst debug),
 4. JavaScript and resources are automaticaly recompiled on file changes,
-5. MusicBrainz Server code is in `musicbrainz-server/` directory.
+5. MusicBrainz Server is automatically restarted on Perl file changes,
+6. MusicBrainz Server code is in `musicbrainz-server/` directory.
 
 After changing code in `musicbrainz-server/`, it can be run as follows:
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,8 @@ The four differences are:
 1. sample data dump is downloaded instead of full data dumps,
 2. MusicBrainz Server runs in standalone mode instead of slave mode,
 3. development mode is enabled (but Catalyst debug),
-4. MusicBrainz Server code is in `musicbrainz-server/` directory.
+4. JavaScript and resources are automaticaly recompiled on file changes,
+5. MusicBrainz Server code is in `musicbrainz-server/` directory.
 
 After changing code in `musicbrainz-server/`, it can be run as follows:
 

--- a/build/musicbrainz-dev/scripts/start.sh
+++ b/build/musicbrainz-dev/scripts/start.sh
@@ -9,4 +9,4 @@ update-perl.sh
 update-javascript.sh
 
 start_mb_renderer.pl
-start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --nproc ${MUSICBRAINZ_SERVER_PROCESSES} --pid fcgi.pid
+start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --nproc ${MUSICBRAINZ_SERVER_PROCESSES} --pid -r fcgi.pid

--- a/build/musicbrainz-dev/scripts/update-javascript.sh
+++ b/build/musicbrainz-dev/scripts/update-javascript.sh
@@ -6,5 +6,6 @@ cd /musicbrainz-server
 
 yarn
 
-dockerize -wait tcp://db:5432 -timeout 60s -wait tcp://mq:5672 -timeout 60s -wait tcp://redis:6379 -timeout 60s ./script/compile_resources.sh
+dockerize -wait tcp://db:5432 -timeout 60s -wait tcp://mq:5672 -timeout 60s -wait tcp://redis:6379 -timeout 60s
 
+./script/compile_resources.sh --watch &> /compile_resources.log &


### PR DESCRIPTION
## MBVM-75: Enable watch mode for JavaScript and Perl in development setup