### PR TITLE
MBVM-76: Replace nproc with max-workers in start_server command

### DIFF
--- a/build/musicbrainz-dev/scripts/start.sh
+++ b/build/musicbrainz-dev/scripts/start.sh
@@ -9,4 +9,4 @@ update-perl.sh
 update-javascript.sh
 
 start_mb_renderer.pl
-start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --nproc ${MUSICBRAINZ_SERVER_PROCESSES} --pid -r fcgi.pid
+start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --max-workers ${MUSICBRAINZ_SERVER_PROCESSES} --pid -r fcgi.pid

--- a/build/musicbrainz/scripts/start.sh
+++ b/build/musicbrainz/scripts/start.sh
@@ -17,4 +17,4 @@ then
   cron -f &
 fi
 
-start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --nproc ${MUSICBRAINZ_SERVER_PROCESSES} --pid fcgi.pid
+start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --max-workers ${MUSICBRAINZ_SERVER_PROCESSES} --pid fcgi.pid


### PR DESCRIPTION
Hello :wave: 

Related to this [ticket](https://tickets.metabrainz.org/browse/MBS-12020) I opened, it seems that this change is fixing the issue.
I managed to increase the number of processes for the web service by using the `max-workers` argument.