### PR TITLE
Add -f to `rm $socket`

### DIFF
--- a/build/musicbrainz-dev/scripts/start_mb_renderer.pl
+++ b/build/musicbrainz-dev/scripts/start_mb_renderer.pl
@@ -7,5 +7,5 @@ use DBDefs;
 
 my $socket = DBDefs->RENDERER_SOCKET;
 
-system("rm $socket");
+system("rm -f $socket");
 system("/musicbrainz-server/script/start_renderer.pl --daemonize --socket $socket");

--- a/build/musicbrainz/scripts/start_mb_renderer.pl
+++ b/build/musicbrainz/scripts/start_mb_renderer.pl
@@ -7,5 +7,5 @@ use DBDefs;
 
 my $socket = DBDefs->RENDERER_SOCKET;
 
-system("rm $socket");
+system("rm -f $socket");
 system("/musicbrainz-server/script/start_renderer.pl --daemonize --socket $socket");


### PR DESCRIPTION
@akshaaatt reported on IRC that this command was failing for him because the socket file didn't exist.  I'm not sure by what mechanism that happens, but adding `-f` to avoid such problems seems wise.