### PR TITLE
Fix interpolation syntax for docker-compose v2

### DIFF
--- a/compose/musicbrainz-dev.yml
+++ b/compose/musicbrainz-dev.yml
@@ -7,7 +7,7 @@ services:
     build:
       context: build/musicbrainz-dev
     volumes:
-      - ${MUSICBRAINZ_SERVER_LOCAL_ROOT:?Missing path of musicbrainz-server working copy}:/musicbrainz-server
+      - ${MUSICBRAINZ_SERVER_LOCAL_ROOT:?Missing path of musicbrainz server working copy}:/musicbrainz-server
     environment:
       - MUSICBRAINZ_CATALYST_DEBUG=${MUSICBRAINZ_CATALYST_DEBUG:-0}
       - MUSICBRAINZ_DEVELOPMENT_SERVER=${MUSICBRAINZ_DEVELOPMENT_SERVER:-1}


### PR DESCRIPTION
v2 doesn't like the hyphen in "musicbrainz server", giving `service "musicbrainz" refers to undefined volume server working copy: invalid compose project` if I don't have `MUSICBRAINZ_SERVER_LOCAL_ROOT` defined in my .env file.