### PR TITLE
Remove memcached and unused Perl cache modules

### DIFF
--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -80,7 +80,6 @@ RUN curl -sSL --retry 5 https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt
         # Needed for XML::LibXML
         libxml2-dev \
         make \
-        memcached \
         # Needed for Unicode::ICU::Collator
         pkg-config \
         postgresql-${POSTGRES_VERSION} \

--- a/build/musicbrainz-dev/scripts/update-perl.sh
+++ b/build/musicbrainz-dev/scripts/update-perl.sh
@@ -8,8 +8,6 @@ diff /DBDefs.pm lib/DBDefs.pm || cat /DBDefs.pm > lib/DBDefs.pm
 
 cpanm --installdeps --notest --with-develop .
 cpanm --notest \
-  Cache::Memcached::Fast \
-  Cache::Memory \
   Catalyst::Plugin::Cache::HTTP \
   Catalyst::Plugin::StackTrace \
   Digest::MD5::File \

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -37,7 +37,6 @@ RUN curl -sSL --retry 5 https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt
         # Needed for XML::LibXML
         libxml2-dev \
         make \
-        memcached \
         # Needed for Unicode::ICU::Collator
         pkg-config \
         postgresql-client-${POSTGRES_VERSION} \
@@ -95,8 +94,6 @@ RUN cp docker/yarn_pubkey.txt /tmp && \
 RUN eval "$(perl -Mlocal::lib)" \
     && cpanm --installdeps --notest . \
     && cpanm --notest \
-        Cache::Memcached::Fast \
-        Cache::Memory \
         Catalyst::Plugin::Cache::HTTP \
         Catalyst::Plugin::StackTrace \
         Digest::MD5::File \


### PR DESCRIPTION
Memcached and the in-memory cache were both removed in 2016:

https://github.com/metabrainz/musicbrainz-server/pull/375
https://github.com/metabrainz/musicbrainz-server/pull/381