### PR TITLE
Limit tcp_max_tw_buckets to avoid connection issues between services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       context: build/musicbrainz
       args:
         - POSTGRES_VERSION=${POSTGRES_VERSION:-12}
+    sysctls:
+      - net.ipv4.tcp_max_tw_buckets=10000
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Related to #211 

By changing the value we enforce the OS to kill sockets that remain in `TIME_WAIT` state and do not allow the services to open new sockets.

```
       tcp_max_tw_buckets (integer; default: see below; since Linux 2.4)
              The maximum number of sockets in TIME_WAIT state allowed in
              the system.  This limit exists only to prevent simple denial-
              of-service attacks.  The default value of NR_FILE*2 is
              adjusted depending on the memory in the system.  If this
              number is exceeded, the socket is closed and a warning is
              printed.
```

A good explanation on a similar case can be found here https://www.percona.com/blog/2014/12/08/what-happens-when-your-application-cannot-open-yet-another-connection-to-mysql/