### PR TITLE
Delete CODE_OF_CONDUCT.md and use org default

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,9 +1,0 @@
-MetaBrainz Code of Conduct
-==========================
-
-This project follows the **[MetaBrainz code of conduct
-](https://metabrainz.org/code-of-conduct
-"Code of Conduct - MetaBrainz Foundation")**.
-
-For questions about the code of conduct or to get help, please email
-support@metabrainz.org or post on https://community.metabrainz.org/


### PR DESCRIPTION
This seems to just link to the org's CoC without adding anything.
Feel free to reject this PR if you want to keep a separate one for some reason, rather than this being a historical artifact :)