### PR TITLE
Install `ts` for development of MusicBrainz script

### DIFF
--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -86,6 +86,8 @@ RUN mkdir -p /usr/local/share/keyrings && \
         # Needed for XML::LibXML
         libxml2-dev \
         make \
+        # Needed for ts
+        moreutils \
         # Needed for Unicode::ICU::Collator
         pkg-config \
         postgresql-${POSTGRES_VERSION} \


### PR DESCRIPTION
Follow https://github.com/metabrainz/musicbrainz-server/pull/2272 that requires `ts` to timestamp the output of scripts but on mirrors.