### PR TITLE
Secure published ports in development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ git clone --recursive https://github.com/metabrainz/musicbrainz-server.git
 MUSICBRAINZ_SERVER_LOCAL_ROOT=$PWD/musicbrainz-server
 git clone https://github.com/metabrainz/musicbrainz-docker.git
 cd musicbrainz-docker
+echo MUSICBRAINZ_DOCKER_HOST_IPADDRCOL=127.0.0.1: >> .env
 echo MUSICBRAINZ_SERVER_LOCAL_ROOT="$MUSICBRAINZ_SERVER_LOCAL_ROOT" >> .env
 admin/configure add musicbrainz-dev
 sudo docker-compose build
@@ -462,6 +463,7 @@ The four differences are:
 4. JavaScript and resources are automaticaly recompiled on file changes,
 5. MusicBrainz Server is automatically restarted on Perl file changes,
 6. MusicBrainz Server code is in `musicbrainz-server/` directory.
+7. Ports are published to the host only (through `MUSICBRAINZ_DOCKER_HOST_IPADDRCOL`)
 
 After changing code in `musicbrainz-server/`, it can be run as follows:
 

--- a/compose/publishing-all-ports.yml
+++ b/compose/publishing-all-ports.yml
@@ -5,14 +5,14 @@ version: '3.1'
 services:
   db:
     ports:
-      - "5432:5432"
+      - "${MUSICBRAINZ_DOCKER_HOST_IPADDRCOL:-}5432:5432"
   search:
     ports:
-      - "8983:8983"
+      - "${MUSICBRAINZ_DOCKER_HOST_IPADDRCOL:-}8983:8983"
   mq:
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "${MUSICBRAINZ_DOCKER_HOST_IPADDRCOL:-}5672:5672"
+      - "${MUSICBRAINZ_DOCKER_HOST_IPADDRCOL:-}15672:15672"
   redis:
     ports:
-      - "6379:6379"
+      - "${MUSICBRAINZ_DOCKER_HOST_IPADDRCOL:-}6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
         max-size: "50m"
         max-file: "50"
     ports:
-      - "${MUSICBRAINZ_WEB_SERVER_PORT:-5000}:5000"
+      - "${MUSICBRAINZ_DOCKER_HOST_IPADDRCOL:-}${MUSICBRAINZ_WEB_SERVER_PORT:-5000}:5000"
     volumes:
       - dbdump:/media/dbdump
       - searchdump:/media/searchdump


### PR DESCRIPTION
By default published ports are listening on all interfaces of the host, making those accessible from the outside in the absence of a firewall. Even though it is the desired behavior when deploying a mirror with replication, it might not be wanted for development or other use case.

This patch allows specifying the host interface to listen to, and recommend listening to the host loopback only for development.

Ref: https://github.com/metabrainz/guidelines/blob/master/Docker.md