### PR TITLE
MBVM-84: Support database-only mirror as an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ git clone https://github.com/metabrainz/musicbrainz-docker.git
 cd musicbrainz-docker
 ```
 
+If you want to mirror the Postgres database only (neither the website
+nor the web API), change the base configuration with the following
+command (as a first step, otherwise it will blank it out):
+
+```bash
+admin/configure with alt-db-only-mirror
+```
+
 ### Build Docker images
 
 Docker images for composed services should be built once using:

--- a/admin/configure
+++ b/admin/configure
@@ -53,6 +53,7 @@ function scan_files {
   shopt -s globstar nullglob
   file_path=(
     docker-compose.yml
+    docker-compose.alt.db-only-mirror.yml
     compose/*.yml
     local/**/*.yml
   )
@@ -60,6 +61,8 @@ function scan_files {
   # Create unique handles
   file_handle[docker-compose.yml]=default
   handle_file[default]=docker-compose.yml
+  file_handle[docker-compose.alt.db-only-mirror.yml]=alt-db-only-mirror
+  handle_file[alt-db-only-mirror]=docker-compose.alt.db-only-mirror.yml
 
   for file in compose/*.yml
   do

--- a/build/musicbrainz/scripts/load-crontab-only.sh
+++ b/build/musicbrainz/scripts/load-crontab-only.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u
+
+dockerize \
+  -wait tcp://db:5432 -timeout 60s \
+  -wait tcp://redis:6379 -timeout 60s \
+  true
+
+if [ -f /crons.conf -a -s /crons.conf ]
+then
+  crontab /crons.conf
+  cron -f &
+fi
+
+sleep infinity

--- a/docker-compose.alt.db-only-mirror.yml
+++ b/docker-compose.alt.db-only-mirror.yml
@@ -1,0 +1,66 @@
+version: '3.1'
+
+# Description: Database-only mirror, as an alternative to 'default'
+
+volumes:
+  pgdata:
+    driver: local
+  dbdump:
+    driver: local
+
+services:
+  db:
+    build:
+      context: build/postgres
+      args:
+        - POSTGRES_VERSION=${POSTGRES_VERSION:-12}
+    image: musicbrainz-docker_db:${POSTGRES_VERSION:-12}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
+    restart: unless-stopped
+    command: postgres -c "shared_buffers=2048MB"
+    env_file:
+      - ./default/postgres.env
+    shm_size: "2GB"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    expose:
+      - "5432"
+
+  musicbrainz:
+    build:
+      context: build/musicbrainz
+      args:
+        - POSTGRES_VERSION=${POSTGRES_VERSION:-12}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "50"
+    volumes:
+      - dbdump:/media/dbdump
+    restart: unless-stopped
+    env_file:
+      - ./default/postgres.env
+    environment:
+      - MUSICBRAINZ_BASE_FTP_URL=${MUSICBRAINZ_BASE_FTP_URL:-ftp://ftp.eu.metabrainz.org/pub/musicbrainz}
+      - MUSICBRAINZ_WEB_SERVER_HOST=${MUSICBRAINZ_WEB_SERVER_HOST:-localhost}
+      - MUSICBRAINZ_WEB_SERVER_PORT=${MUSICBRAINZ_WEB_SERVER_PORT:-5000}
+    command: load-crontab-only.sh
+    depends_on:
+      - db
+      - redis
+
+  redis:
+    image: redis:3-alpine
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
+    restart: unless-stopped
+    expose:
+      - "6379"


### PR DESCRIPTION
# MBVM-84: Support database-only mirror

## Problem

The default configuration assumes that the web stuff should be mirrored as well.

## Solution

Before building images or any other configuration step,
replace the default `docker-compose.yml` with alternative `docker-compose.alt.db-only-mirror.yml` as follows:

```bash
admin/configure with alt-db-only-mirror
```

## Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Test installing a database mirror from scratch
* [x] Update `README.md`