### PR TITLE
MBVM-85: Rename "slave" to "mirror"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# MusicBrainz slave server with search and replication
+# MusicBrainz mirror server with search and replication
 
 [![Build Status](https://travis-ci.org/metabrainz/musicbrainz-docker.svg?branch=master)](https://travis-ci.org/metabrainz/musicbrainz-docker)
 
-This repo contains everything needed to run a musicbrainz slave server with search and replication in docker.
+This repo contains everything needed to run a musicbrainz mirror server with search and replication in docker.
 
 ## Table of contents
 
@@ -91,7 +91,7 @@ If you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall:
 
 ## Installation
 
-This section is about installing MusicBrainz slave server (mirror)
+This section is about installing MusicBrainz mirror server
 with locally indexed search and automatically replicated data.
 
 Download this repository and change current working directory with:
@@ -210,7 +210,7 @@ Run replication script once to catch up with latest database updates:
 
 ```bash
 sudo docker-compose exec musicbrainz replication.sh &
-sudo docker-compose exec musicbrainz /usr/bin/tail -f slave.log
+sudo docker-compose exec musicbrainz /usr/bin/tail -f mirror.log
 ```
 
 <!-- TODO: estimate replication time per missing day -->
@@ -231,18 +231,18 @@ To change that, see [advanced configuration](#advanced-configuration).
 You can view the replication log file while it is running with:
 
 ```bash
-sudo docker-compose exec musicbrainz tail --follow slave.log
+sudo docker-compose exec musicbrainz tail --follow mirror.log
 ```
 
 You can view the replication log file after it is done with:
 
 ```bash
-sudo docker-compose exec musicbrainz tail slave.log.1
+sudo docker-compose exec musicbrainz tail mirror.log.1
 ```
 
 ### Enable live indexing
 
-:warning: Search indexes’ live update for slave server is **not stable** yet.
+:warning: Search indexes’ live update for mirror server is **not stable** yet.
 Until then, it should be considered as an experimental feature.
 Do not use it if you don't want to get your hands dirty.
 
@@ -444,7 +444,7 @@ sudo docker-compose up -d
 
 The two differences are:
 1. sample data dump is downloaded instead of full data dumps,
-2. MusicBrainz Server runs in standalone mode instead of slave mode.
+2. MusicBrainz Server runs in standalone mode instead of mirror mode.
 
 [Build search indexes](#build-search-indexes) and
 [Enable live indexing](#enable-live-indexing) are the same.
@@ -477,7 +477,7 @@ sudo docker-compose up -d
 
 The four differences are:
 1. sample data dump is downloaded instead of full data dumps,
-2. MusicBrainz Server runs in standalone mode instead of slave mode,
+2. MusicBrainz Server runs in standalone mode instead of mirror mode,
 3. development mode is enabled (but Catalyst debug),
 4. JavaScript and resources are automaticaly recompiled on file changes,
 5. MusicBrainz Server is automatically restarted on Perl file changes,

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -127,22 +127,22 @@ sub DB_SCHEMA_SEQUENCE { 27 }
 # What type of server is this?
 # * RT_MASTER - This is a master replication server.  Changes are allowed, and
 #               they result in replication packets being produced.
-# * RT_SLAVE  - This is a slave replication server.  After loading a snapshot
+# * RT_MIRROR - This is a mirror replication server.  After loading a snapshot
 #               produced by a master, the only changes allowed are those made
-#               by applying the next replication packet in turn.  If the slave
+#               by applying the next replication packet in turn.  If the mirror
 #               server is not going to be used for development work, change
 #               DB_STAGING_SERVER to 0.
 #
 #               A READONLY database connection must be configured if you
-#               choose RT_SLAVE, as well as the usual READWRITE.
+#               choose RT_MIRROR, as well as the usual READWRITE.
 # * RT_STANDALONE - This server neither generates nor uses replication
 #               packets.  Changes to the database are allowed.
 sub REPLICATION_TYPE { $ENV{MUSICBRAINZ_STANDALONE_SERVER} == 1
     ? RT_STANDALONE
-    : RT_SLAVE
+    : RT_MIRROR
 }
 
-# If you plan to use the RT_SLAVE setting (replicated data from MusicBrainz' Live Data Feed)
+# If you plan to use the RT_MIRROR setting (replicated data from MusicBrainz' Live Data Feed)
 # you must sign in at https://metabrainz.org and generate an access token to access
 # the replication packets. Enter the access token below:
 # NOTE: DO NOT EXPOSE THIS ACCESS TOKEN PUBLICLY!
@@ -220,7 +220,7 @@ sub SEARCH_ENGINE             { "SOLR" }
 # Server Settings
 ################################################################################
 
-# Set this to 0 if this is the master MusicBrainz server or a slave mirror.
+# Set this to 0 if this is the master MusicBrainz server or a mirror server.
 # Keeping this defined enables the banner that is shown across the top of each
 # page, as well as some testing features that are only enabled when not on
 # the live server.

--- a/build/musicbrainz-dev/scripts/replication.sh
+++ b/build/musicbrainz-dev/scripts/replication.sh
@@ -3,4 +3,4 @@
 set -e
 
 dockerize -wait tcp://db:5432 -timeout 60s sleep 0
-exec /musicbrainz-server/admin/cron/slave.sh
+exec /musicbrainz-server/admin/cron/mirror.sh

--- a/build/musicbrainz/DBDefs.pm
+++ b/build/musicbrainz/DBDefs.pm
@@ -114,22 +114,22 @@ sub DB_SCHEMA_SEQUENCE { $ENV{MUSICBRAINZ_DB_SCHEMA_SEQUENCE} }
 # What type of server is this?
 # * RT_MASTER - This is a master replication server.  Changes are allowed, and
 #               they result in replication packets being produced.
-# * RT_SLAVE  - This is a slave replication server.  After loading a snapshot
+# * RT_MIRROR - This is a mirror replication server.  After loading a snapshot
 #               produced by a master, the only changes allowed are those made
-#               by applying the next replication packet in turn.  If the slave
+#               by applying the next replication packet in turn.  If the mirror
 #               server is not going to be used for development work, change
 #               DB_STAGING_SERVER to 0.
 #
 #               A READONLY database connection must be configured if you
-#               choose RT_SLAVE, as well as the usual READWRITE.
+#               choose RT_MIRROR, as well as the usual READWRITE.
 # * RT_STANDALONE - This server neither generates nor uses replication
 #               packets.  Changes to the database are allowed.
 sub REPLICATION_TYPE { $ENV{MUSICBRAINZ_STANDALONE_SERVER} == 1
     ? RT_STANDALONE
-    : RT_SLAVE
+    : RT_MIRROR
 }
 
-# If you plan to use the RT_SLAVE setting (replicated data from MusicBrainz' Live Data Feed)
+# If you plan to use the RT_MIRROR setting (replicated data from MusicBrainz' Live Data Feed)
 # you must sign in at https://metabrainz.org and generate an access token to access
 # the replication packets. Enter the access token below:
 # NOTE: DO NOT EXPOSE THIS ACCESS TOKEN PUBLICLY!
@@ -207,7 +207,7 @@ sub SEARCH_ENGINE             { "SOLR" }
 # Server Settings
 ################################################################################
 
-# Set this to 0 if this is the master MusicBrainz server or a slave mirror.
+# Set this to 0 if this is the master MusicBrainz server or a mirror server.
 # Keeping this defined enables the banner that is shown across the top of each
 # page, as well as some testing features that are only enabled when not on
 # the live server.

--- a/build/musicbrainz/scripts/replication.sh
+++ b/build/musicbrainz/scripts/replication.sh
@@ -3,4 +3,4 @@
 set -e
 
 dockerize -wait tcp://db:5432 -timeout 60s sleep 0
-exec /musicbrainz-server/admin/cron/slave.sh
+exec /musicbrainz-server/admin/cron/mirror.sh


### PR DESCRIPTION
# MBVM-85: Rename "slave" to "mirror"

It follows the changes made for MBS-12225 in the latest MusicBrainz Server schema change release.

* Use "mirror.sh" instead of "slave.sh" (even though the latter still exists as a link)
* Follow changes made to "DBDefs.pm.sample" (especially deprecated bits)
* Make similar renaming in the documentation

Only change to commands: The replication log file is now named "mirror.log".

Resolve issue https://github.com/metabrainz/musicbrainz-docker/issues/227