### PR TITLE
Replace virtualenv with user site-packages directory for SIR development

### DIFF
--- a/build/sir-dev/Dockerfile
+++ b/build/sir-dev/Dockerfile
@@ -29,8 +29,6 @@ RUN apt-get update \
       libsqlite3-dev \
       # required by lxml from mb-rngpy
       libxslt1-dev \
-      # required to initialize the virtual environment (development setup)
-      virtualenv \
     && rm -rf /var/lib/apt/lists/*
 
 ##################
@@ -56,8 +54,8 @@ WORKDIR /code
 
 ENV POSTGRES_USER=musicbrainz
 ENV POSTGRES_PASSWORD=musicbrainz
-ENV PYTHONPATH="/code/venv-musicbrainz-docker/lib/python2.7"
+ENV PYTHONUSERBASE="/code/venv-musicbrainz-docker"
 ENV PATH="/code/venv-musicbrainz-docker/bin:$PATH"
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD unset PYTHONPATH; my_init
+CMD unset PYTHONUSERBASE; my_init

--- a/build/sir-dev/scripts/docker-entrypoint.sh
+++ b/build/sir-dev/scripts/docker-entrypoint.sh
@@ -2,24 +2,12 @@
 
 set -e -u
 
-if ! [[ -x /code/venv-musicbrainz-docker/bin/python2 ]]
-then
-  (
-    unset PYTHONPATH
-    virtualenv \
-      --python=python2 \
-      --system-site-packages \
-      --verbose \
-      /code/venv-musicbrainz-docker
-  )
-fi
-
-mkdir -p .cache
+mkdir -p .cache venv-musicbrainz-docker
 
 pip install \
   --cache-dir /code/.cache \
   --disable-pip-version-check \
-  --prefix /code/venv-musicbrainz-docker \
+  --user \
   -r requirements.txt \
   -r requirements_dev.txt
 


### PR DESCRIPTION
For SIR development setup only, so far its dependencies were installed in a Python virtual environment, without enabling it (to allow running command with `docker-compose exec`) which was a hack that is no longer working with the new Python base image 2.7-20220421 used since SIR 3.

Instead this patch sets user Python site-packages directory to point to the same location `/code/venv-musicbrainz-docker` (which is matched by `sir/.gitignore`) and install the dependencies to it. This change should be transparent to previously installed SIR development setup.

## Checklist for readiness

* [x] Test live indexing

Test running `py.test` would require running an instance of `musicbrainz-test-database`. This is already available from `sir` repository so it isn’t useful to duplicate it here.