### PR TITLE
Support Windows for development setup only

### DIFF
--- a/admin/configure
+++ b/admin/configure
@@ -206,6 +206,12 @@ case "$1" in
     sed -i.bak -e '/^COMPOSE_FILE=/d' .env && rm -f .env.bak
     if [[ $OS == Windows_NT ]]
     then
+      # Optional but convenient to copy/paste paths from file explorer
+      # https://docs.docker.com/compose/reference/envvars/#compose_convert_windows_paths
+      if ! grep -q '^COMPOSE_CONVERT_WINDOWS_PATHS=' "$MB_DOCKER_ROOT/.env"
+      then
+        echo 'COMPOSE_CONVERT_WINDOWS_PATHS=1' >> .env
+      fi
       # Mandatory to keep this script working
       # https://docs.docker.com/compose/reference/envvars/#compose_path_separator
       if ! grep -q '^COMPOSE_PATH_SEPARATOR=:$' "$MB_DOCKER_ROOT/.env"

--- a/admin/configure
+++ b/admin/configure
@@ -204,6 +204,15 @@ case "$1" in
     # Write to .env
     touch .env
     sed -i.bak -e '/^COMPOSE_FILE=/d' .env && rm -f .env.bak
+    if [[ $OS == Windows_NT ]]
+    then
+      # Mandatory to keep this script working
+      # https://docs.docker.com/compose/reference/envvars/#compose_path_separator
+      if ! grep -q '^COMPOSE_PATH_SEPARATOR=:$' "$MB_DOCKER_ROOT/.env"
+      then
+        echo 'COMPOSE_PATH_SEPARATOR=:' >> .env
+      fi
+    fi
     echo "COMPOSE_FILE=$(IFS=:; echo "${compose_files[*]}")" >> .env
     echo "Successfully set/updated COMPOSE_FILE in '$MB_DOCKER_ROOT/.env'."
     exit 0 # EX_OK

--- a/admin/lib/common.inc.bash
+++ b/admin/lib/common.inc.bash
@@ -35,9 +35,16 @@ then
       fi
       ;;
     *)
-      echo >&2 "$SCRIPT_NAME: cannot detect platform to set docker command"
-      echo >&2 "Try setting the variable \$DOCKER_CMD appropriately"
-      exit 71 # EX_OSERR
+      case "$OS" in
+        Windows_NT)
+          DOCKER_CMD='docker'
+          ;;
+        *)
+          echo >&2 "$SCRIPT_NAME: cannot detect platform to set docker command"
+          echo >&2 "Try setting the variable \$DOCKER_CMD appropriately"
+          exit 71 # EX_OSERR
+          ;;
+      esac
       ;;
   esac
 fi
@@ -63,9 +70,16 @@ then
       fi
       ;;
     *)
-      echo >&2 "$SCRIPT_NAME: cannot detect platform to set docker-compose command"
-      echo >&2 "Try setting the variable \$DOCKER_COMPOSE_CMD appropriately"
-      exit 71 # EX_OSERR
+      case "$OS" in
+        Windows_NT)
+          DOCKER_COMPOSE_CMD='docker-compose'
+          ;;
+        *)
+          echo >&2 "$SCRIPT_NAME: cannot detect platform to set docker-compose command"
+          echo >&2 "Try setting the variable \$DOCKER_COMPOSE_CMD appropriately"
+          exit 71 # EX_OSERR
+          ;;
+      esac
       ;;
   esac
 fi


### PR DESCRIPTION
It is an attempt to support running MusicBrainz Server development setup on Windows, using Docker and GitBash (MinGW-w64).

It isn’t a full implementation of MBVM-53 but it might help with it in the end.

# Todolist

* [x] Detect platform and set Docker commands
* [x] Set [`COMPOSE_PATH_SEPARATOR`](https://docs.docker.com/compose/reference/envvars/#compose_path_separator) which is different on Windows
* [x] Enable [`COMPOSE_CONVERT_WINDOWS_PATHS`](https://docs.docker.com/compose/reference/envvars/#compose_convert_windows_paths) to help with copy/paste from the file explorer
* [ ] Test with a kiwi
* [ ] Document requirements and additional installation steps
* [ ] Solve any further issue