### PR TITLE
MBVM-88: Fetch DB dumps via HTTP instead of FTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,19 +341,19 @@ By default, MusicBrainz Server uses 10 `plackup` processes at once.
 This number can be changed using the Docker environment variable
 `MUSICBRAINZ_SERVER_PROCESSES`.
 
-#### Customize mirror server
+#### Customize download server
 
 By default, data dumps and pre-built search indexes are downloaded from
 `http://ftp.eu.metabrainz.org/pub/musicbrainz`.
 
-The mirror server can be changed using the Docker environment variable
-`MUSICBRAINZ_MIRROR_URL`.
+The download server can be changed using the Docker environment variable
+`MUSICBRAINZ_BASE_DOWNLOAD_URL`.
 
-For backwards compatibility reasons an FTP mirror can be specified using the
+For backwards compatibility reasons an FTP server can be specified using the
 `MUSICBRAINZ_BASE_FTP_URL` Docker environment variable. Note that support for
 this variable is deprecated and will be removed in a future release.
 
-See the [list of mirrors](https://musicbrainz.org/doc/MusicBrainz_Database/Download#Download)
+See the [list of download servers](https://musicbrainz.org/doc/MusicBrainz_Database/Download#Download)
 for alternative download sources.
 
 #### Customize replication schedule

--- a/README.md
+++ b/README.md
@@ -341,16 +341,20 @@ By default, MusicBrainz Server uses 10 `plackup` processes at once.
 This number can be changed using the Docker environment variable
 `MUSICBRAINZ_SERVER_PROCESSES`.
 
-#### Customize FTP mirror
+#### Customize mirror server
 
 By default, data dumps and pre-built search indexes are downloaded from
-`ftp://ftp.eu.metabrainz.org/pub/musicbrainz`.
+`http://ftp.eu.metabrainz.org/pub/musicbrainz`.
 
-The FTP mirror can be changed using the Docker environment variable
-`MUSICBRAINZ_BASE_FTP_URL`.
+The mirror server can be changed using the Docker environment variable
+`MUSICBRAINZ_MIRROR_URL`.
 
-See also the [list of mirrors](https://musicbrainz.org/doc/MusicBrainz_Database/Download#Download);
-Only FTP URLs are supported here.
+For backwards compatibility reasons an FTP mirror can be specified using the
+`MUSICBRAINZ_BASE_FTP_URL` Docker environment variable. Note that support for
+this variable is deprecated and will be removed in a future release.
+
+See the [list of mirrors](https://musicbrainz.org/doc/MusicBrainz_Database/Download#Download)
+for alternative download sources.
 
 #### Customize replication schedule
 

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -116,7 +116,7 @@ ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
 ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
 
 ENV BASH_ENV=/noninteractive.bash_env \
-    MUSICBRAINZ_MIRROR_URL=http://ftp.eu.metabrainz.org/pub/musicbrainz \
+    MUSICBRAINZ_BASE_DOWNLOAD_URL=http://ftp.eu.metabrainz.org/pub/musicbrainz \
     MUSICBRAINZ_CATALYST_DEBUG=0 \
     MUSICBRAINZ_DEVELOPMENT_SERVER=1 \
     MUSICBRAINZ_SEARCH_SERVER=search:8983/solr \

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -116,7 +116,7 @@ ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
 ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
 
 ENV BASH_ENV=/noninteractive.bash_env \
-    MUSICBRAINZ_BASE_FTP_URL=ftp://ftp.eu.metabrainz.org/pub/musicbrainz \
+    MUSICBRAINZ_MIRROR_URL=http://ftp.eu.metabrainz.org/pub/musicbrainz \
     MUSICBRAINZ_CATALYST_DEBUG=0 \
     MUSICBRAINZ_DEVELOPMENT_SERVER=1 \
     MUSICBRAINZ_SEARCH_SERVER=search:8983/solr \

--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -2,21 +2,21 @@
 
 set -e -o pipefail -u
 
-FTP_MB="$MUSICBRAINZ_BASE_FTP_URL"
+MIRROR_URL="${MUSICBRAINZ_BASE_FTP_URL:-$MUSICBRAINZ_MIRROR_URL}"
 IMPORT="fullexport"
 FETCH_DUMPS=""
 WGET_OPTIONS=""
 
 HELP=$(cat <<EOH
-Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_FTP_URL]
+Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_MIRROR_URL]
 
 Options:
-  -fetch      Fetch latest dump from MusicBrainz FTP
+  -fetch      Fetch latest dump from MusicBrainz mirror server
   -sample     Load sample data instead of full data
   -wget-opts  Pass additional space-separated options list (should be
               a single argument, escape spaces if necessary) to wget
 
-Default MusicBrainz FTP URL: $FTP_MB
+Default MusicBrainz mirror URL: $MIRROR_URL
 EOH
 )
 
@@ -44,7 +44,7 @@ while [ $# -gt 0 ]; do
             exit 1
             ;;
         *       )
-            FTP_MB="$1"
+            MIRROR_URL="$1"
             ;;
     esac
     shift
@@ -79,7 +79,7 @@ case "$IMPORT" in
 esac
 
 if [[ $FETCH_DUMPS == "-fetch" ]]; then
-    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --base-ftp-url "$FTP_MB")
+    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --mirror-url "$MIRROR_URL")
     if [[ -n "$WGET_OPTIONS" ]]; then
         FETCH_OPTIONS+=(--wget-options "$WGET_OPTIONS")
     fi

--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -2,21 +2,21 @@
 
 set -e -o pipefail -u
 
-MIRROR_URL="${MUSICBRAINZ_BASE_FTP_URL:-$MUSICBRAINZ_MIRROR_URL}"
+BASE_DOWNLOAD_URL="${MUSICBRAINZ_BASE_FTP_URL:-$MUSICBRAINZ_BASE_DOWNLOAD_URL}"
 IMPORT="fullexport"
 FETCH_DUMPS=""
 WGET_OPTIONS=""
 
 HELP=$(cat <<EOH
-Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_MIRROR_URL]
+Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_BASE_DOWNLOAD_URL]
 
 Options:
-  -fetch      Fetch latest dump from MusicBrainz mirror server
+  -fetch      Fetch latest dump from MusicBrainz download server
   -sample     Load sample data instead of full data
   -wget-opts  Pass additional space-separated options list (should be
               a single argument, escape spaces if necessary) to wget
 
-Default MusicBrainz mirror URL: $MIRROR_URL
+Default MusicBrainz base download URL: $BASE_DOWNLOAD_URL
 EOH
 )
 
@@ -44,7 +44,7 @@ while [ $# -gt 0 ]; do
             exit 1
             ;;
         *       )
-            MIRROR_URL="$1"
+            BASE_DOWNLOAD_URL="$1"
             ;;
     esac
     shift
@@ -79,7 +79,7 @@ case "$IMPORT" in
 esac
 
 if [[ $FETCH_DUMPS == "-fetch" ]]; then
-    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --mirror-url "$MIRROR_URL")
+    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --base-download-url "$BASE_DOWNLOAD_URL")
     if [[ -n "$WGET_OPTIONS" ]]; then
         FETCH_OPTIONS+=(--wget-options "$WGET_OPTIONS")
     fi

--- a/build/musicbrainz-dev/scripts/fetch-dump.sh
+++ b/build/musicbrainz-dev/scripts/fetch-dump.sh
@@ -22,10 +22,10 @@ Targets:
   search        Fetch latest search indexes only.
 
 Options:
-  --base-ftp-url <url>          Specify URL of a MetaBrainz/MusicBrainz FTP server.
-                                (Note: this option is deprecated and will be removed in a future release)
   --base-download-url <url>     Specify URL of a MetaBrainz/MusicBrainz download server.
                                 (Default: '$BASE_DOWNLOAD_URL')
+  --base-ftp-url <url>          Specify URL of a MetaBrainz/MusicBrainz FTP server.
+                                (Note: this option is deprecated and will be removed in a future release)
   --wget-options <wget options> Specify additional options to be passed to wget,
                                 these should be separated with whitespace,
                                 the list should be a single argument
@@ -49,15 +49,6 @@ do
 			fi
 			TARGET=$1
 			;;
-		--base-ftp-url )
-			shift
-			echo >&2 "WARNING: --base-ftp-url is deprecated and will be removed in a future release"
-			BASE_FTP_URL="$1"
-			if ! [[ $BASE_FTP_URL =~ ^ftp:// ]]
-			then
-				BASE_FTP_URL="ftp://$BASE_FTP_URL"
-			fi
-			;;
 		--base-download-url )
 			shift
 			BASE_DOWNLOAD_URL="$1"
@@ -65,6 +56,15 @@ do
 			then
 				echo >&2 "$SCRIPT_NAME: --base-download-url must begin with ftp://, http:// or https://"
 				exit 64 # EX_USAGE
+			fi
+			;;
+		--base-ftp-url )
+			shift
+			echo >&2 "WARNING: --base-ftp-url is deprecated and will be removed in a future release"
+			BASE_FTP_URL="$1"
+			if ! [[ $BASE_FTP_URL =~ ^ftp:// ]]
+			then
+				BASE_FTP_URL="ftp://$BASE_FTP_URL"
 			fi
 			;;
 		--wget-options )

--- a/build/musicbrainz-dev/scripts/fetch-dump.sh
+++ b/build/musicbrainz-dev/scripts/fetch-dump.sh
@@ -52,7 +52,7 @@ do
 		--base-download-url )
 			shift
 			BASE_DOWNLOAD_URL="$1"
-			if ! [[ $BASE_DOWNLOAD_URL =~ "^(ftp|https?)://" ]]
+			if ! [[ $BASE_DOWNLOAD_URL =~ ^(ftp|https?):// ]]
 			then
 				echo >&2 "$SCRIPT_NAME: --base-download-url must begin with ftp://, http:// or https://"
 				exit 64 # EX_USAGE

--- a/build/musicbrainz-dev/scripts/fetch-dump.sh
+++ b/build/musicbrainz-dev/scripts/fetch-dump.sh
@@ -4,7 +4,8 @@ set -e -o pipefail -u
 
 DB_DUMP_DIR=/media/dbdump
 SEARCH_DUMP_DIR=/media/searchdump
-BASE_FTP_URL="$MUSICBRAINZ_BASE_FTP_URL"
+BASE_FTP_URL=''
+MIRROR_URL="$MUSICBRAINZ_MIRROR_URL"
 TARGET=''
 WGET_CMD=(wget)
 
@@ -21,14 +22,16 @@ Targets:
   search        Fetch latest search indexes only.
 
 Options:
-  --base-ftp-url <url>          Specify URL to MetaBrainz/MusicBrainz FTP directory.
-                                (Default: '$BASE_FTP_URL')
+  --base-ftp-url <url>          Specify URL of a MetaBrainz/MusicBrainz FTP mirror server.
+                                (Note: this option is deprecated and will be removed in a future release)
+  --mirror-url <url>            Specify URL of a MetaBrainz/MusicBrainz mirror server.
+                                (Default: '$MIRROR_URL')
   --wget-options <wget options> Specify additional options to be passed to wget,
                                 these should be separated with whitespace,
                                 the list should be a single argument
                                 (escape whitespaces if needed).
 
-  -h, --help                    Print this help message.
+  -h, --help                    Print this help message and exit.
 EOH
 )
 
@@ -48,10 +51,20 @@ do
 			;;
 		--base-ftp-url )
 			shift
+			echo >&2 "WARNING: --base-ftp-url is deprecated and will be removed in a future release"
 			BASE_FTP_URL="$1"
 			if ! [[ $BASE_FTP_URL =~ ^ftp:// ]]
 			then
 				BASE_FTP_URL="ftp://$BASE_FTP_URL"
+			fi
+			;;
+		--mirror-url )
+			shift
+			MIRROR_URL="$1"
+			if ! [[ $MIRROR_URL =~ "^(ftp|https?)://" ]]
+			then
+				echo >&2 "$SCRIPT_NAME: --mirror-url must begin with ftp://, http:// or https://"
+				exit 64 # EX_USAGE
 			fi
 			;;
 		--wget-options )
@@ -92,10 +105,10 @@ then
 	echo "$(date): Fetching search indexes dump..."
 	cd "$SEARCH_DUMP_DIR" && find . -delete && cd -
 	"${WGET_CMD[@]}" -nd -nH -P "$SEARCH_DUMP_DIR" \
-		"$BASE_FTP_URL/data/search-indexes/LATEST"
+		"${BASE_FTP_URL:-$MIRROR_URL}/data/search-indexes/LATEST"
 	DUMP_TIMESTAMP=$(cat /media/searchdump/LATEST)
 	"${WGET_CMD[@]}" -nd -nH -r -P "$SEARCH_DUMP_DIR" \
-		"$BASE_FTP_URL/data/search-indexes/$DUMP_TIMESTAMP/"
+		"${BASE_FTP_URL:-$MIRROR_URL}/data/search-indexes/$DUMP_TIMESTAMP/"
 	cd "$SEARCH_DUMP_DIR" && md5sum -c MD5SUMS && cd -
 	if [[ $TARGET == search ]]
 	then
@@ -139,7 +152,7 @@ then
 
 	SEARCH_DUMP_DAY="${DUMP_TIMESTAMP/-*}"
 	"${WGET_CMD[@]}" --spider --no-remove-listing -P "$DB_DUMP_DIR" \
-		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR"
+		"${BASE_FTP_URL:-$MIRROR_URL}/$DB_DUMP_REMOTE_DIR"
 	DUMP_TIMESTAMP=$(
 		grep -E "\\s${SEARCH_DUMP_DAY}-\\d*" "$DB_DUMP_DIR/.listing" \
 			| sed -e 's/\s*$//' -e 's/.*\s//'
@@ -151,7 +164,7 @@ then
 	# Just find latest database dump
 
 	"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
-		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
+		"${BASE_FTP_URL:-$MIRROR_URL}/$DB_DUMP_REMOTE_DIR/LATEST"
 	DUMP_TIMESTAMP=$(cat "$DB_DUMP_DIR/LATEST")
 fi
 
@@ -162,7 +175,7 @@ then
 	for F in MD5SUMS "${DB_DUMP_FILES[@]}"
 	do
 		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
-			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+			"${BASE_FTP_URL:-$MIRROR_URL}/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
 	done
 	cd "$DB_DUMP_DIR"
 	for F in "${DB_DUMP_FILES[@]}"
@@ -179,7 +192,7 @@ then
 	for F in "${DB_DUMP_FILES[@]}"
 	do
 		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
-			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+			"${BASE_FTP_URL:-$MIRROR_URL}/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
 	done
 fi
 

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -124,7 +124,7 @@ ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
 ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
 
 ENV BASH_ENV=/noninteractive.bash_env \
-    MUSICBRAINZ_BASE_FTP_URL=ftp://ftp.eu.metabrainz.org/pub/musicbrainz \
+    MUSICBRAINZ_MIRROR_URL=http://ftp.eu.metabrainz.org/pub/musicbrainz \
     MUSICBRAINZ_CATALYST_DEBUG=0 \
     MUSICBRAINZ_DB_SCHEMA_SEQUENCE=27 \
     MUSICBRAINZ_DEVELOPMENT_SERVER=0 \

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -124,7 +124,7 @@ ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
 ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
 
 ENV BASH_ENV=/noninteractive.bash_env \
-    MUSICBRAINZ_MIRROR_URL=http://ftp.eu.metabrainz.org/pub/musicbrainz \
+    MUSICBRAINZ_BASE_DOWNLOAD_URL=http://ftp.eu.metabrainz.org/pub/musicbrainz \
     MUSICBRAINZ_CATALYST_DEBUG=0 \
     MUSICBRAINZ_DB_SCHEMA_SEQUENCE=27 \
     MUSICBRAINZ_DEVELOPMENT_SERVER=0 \

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -2,21 +2,21 @@
 
 set -e -o pipefail -u
 
-MIRROR_URL="${MUSICBRAINZ_BASE_FTP_URL:-$MUSICBRAINZ_MIRROR_URL}"
+BASE_DOWNLOAD_URL="${MUSICBRAINZ_BASE_FTP_URL:-$MUSICBRAINZ_BASE_DOWNLOAD_URL}"
 IMPORT="fullexport"
 FETCH_DUMPS=""
 WGET_OPTIONS=""
 
 HELP=$(cat <<EOH
-Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_MIRROR_URL]
+Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_BASE_DOWNLOAD_URL]
 
 Options:
-  -fetch      Fetch latest dump from MusicBrainz mirror server
+  -fetch      Fetch latest dump from MusicBrainz download server
   -sample     Load sample data instead of full data
   -wget-opts  Pass additional space-separated options list (should be
               a single argument, escape spaces if necessary) to wget
 
-Default MusicBrainz mirror URL: $MIRROR_URL
+Default MusicBrainz download base URL: $BASE_DOWNLOAD_URL
 EOH
 )
 
@@ -44,7 +44,7 @@ while [ $# -gt 0 ]; do
             exit 1
             ;;
         *       )
-            MIRROR_URL="$1"
+            BASE_DOWNLOAD_URL="$1"
             ;;
     esac
     shift
@@ -79,7 +79,7 @@ case "$IMPORT" in
 esac
 
 if [[ $FETCH_DUMPS == "-fetch" ]]; then
-    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --mirror-url "$MIRROR_URL")
+    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --base-download-url "$BASE_DOWNLOAD_URL")
     if [[ -n "$WGET_OPTIONS" ]]; then
         FETCH_OPTIONS+=(--wget-options "$WGET_OPTIONS")
     fi

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -2,21 +2,21 @@
 
 set -e -o pipefail -u
 
-FTP_MB="$MUSICBRAINZ_BASE_FTP_URL"
+MIRROR_URL="${MUSICBRAINZ_BASE_FTP_URL:-$MUSICBRAINZ_MIRROR_URL}"
 IMPORT="fullexport"
 FETCH_DUMPS=""
 WGET_OPTIONS=""
 
 HELP=$(cat <<EOH
-Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_FTP_URL]
+Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_MIRROR_URL]
 
 Options:
-  -fetch      Fetch latest dump from MusicBrainz FTP
+  -fetch      Fetch latest dump from MusicBrainz mirror server
   -sample     Load sample data instead of full data
   -wget-opts  Pass additional space-separated options list (should be
               a single argument, escape spaces if necessary) to wget
 
-Default MusicBrainz FTP URL: $FTP_MB
+Default MusicBrainz mirror URL: $MIRROR_URL
 EOH
 )
 
@@ -44,7 +44,7 @@ while [ $# -gt 0 ]; do
             exit 1
             ;;
         *       )
-            FTP_MB="$1"
+            MIRROR_URL="$1"
             ;;
     esac
     shift
@@ -79,7 +79,7 @@ case "$IMPORT" in
 esac
 
 if [[ $FETCH_DUMPS == "-fetch" ]]; then
-    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --base-ftp-url "$FTP_MB")
+    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --mirror-url "$MIRROR_URL")
     if [[ -n "$WGET_OPTIONS" ]]; then
         FETCH_OPTIONS+=(--wget-options "$WGET_OPTIONS")
     fi

--- a/build/musicbrainz/scripts/fetch-dump.sh
+++ b/build/musicbrainz/scripts/fetch-dump.sh
@@ -22,10 +22,10 @@ Targets:
   search        Fetch latest search indexes only.
 
 Options:
-  --base-ftp-url <url>          Specify URL of a MetaBrainz/MusicBrainz FTP server.
-                                (Note: this option is deprecated and will be removed in a future release)
   --base-download-url <url>     Specify URL of a MetaBrainz/MusicBrainz download server.
                                 (Default: '$BASE_DOWNLOAD_URL')
+  --base-ftp-url <url>          Specify URL of a MetaBrainz/MusicBrainz FTP server.
+                                (Note: this option is deprecated and will be removed in a future release)
   --wget-options <wget options> Specify additional options to be passed to wget,
                                 these should be separated with whitespace,
                                 the list should be a single argument
@@ -49,15 +49,6 @@ do
 			fi
 			TARGET=$1
 			;;
-		--base-ftp-url )
-			shift
-			echo >&2 "Warning: --base-ftp-url is deprecated and will be removed in a future release"
-			BASE_FTP_URL="$1"
-			if ! [[ $BASE_FTP_URL =~ ^ftp:// ]]
-			then
-				BASE_FTP_URL="ftp://$BASE_FTP_URL"
-			fi
-			;;
 		--base-download-url )
 			shift
 			BASE_DOWNLOAD_URL="$1"
@@ -65,6 +56,15 @@ do
 			then
 				echo >&2 "$SCRIPT_NAME: --base-download-url must begin with ftp://, http:// or https://"
 				exit 64 # EX_USAGE
+			fi
+			;;
+		--base-ftp-url )
+			shift
+			echo >&2 "Warning: --base-ftp-url is deprecated and will be removed in a future release"
+			BASE_FTP_URL="$1"
+			if ! [[ $BASE_FTP_URL =~ ^ftp:// ]]
+			then
+				BASE_FTP_URL="ftp://$BASE_FTP_URL"
 			fi
 			;;
 		--wget-options )

--- a/build/musicbrainz/scripts/fetch-dump.sh
+++ b/build/musicbrainz/scripts/fetch-dump.sh
@@ -52,7 +52,7 @@ do
 		--base-download-url )
 			shift
 			BASE_DOWNLOAD_URL="$1"
-			if ! [[ $BASE_DOWNLOAD_URL =~ "^(ftp|https?)://" ]]
+			if ! [[ $BASE_DOWNLOAD_URL =~ ^(ftp|https?):// ]]
 			then
 				echo >&2 "$SCRIPT_NAME: --base-download-url must begin with ftp://, http:// or https://"
 				exit 64 # EX_USAGE

--- a/build/musicbrainz/scripts/fetch-dump.sh
+++ b/build/musicbrainz/scripts/fetch-dump.sh
@@ -4,7 +4,8 @@ set -e -o pipefail -u
 
 DB_DUMP_DIR=/media/dbdump
 SEARCH_DUMP_DIR=/media/searchdump
-BASE_FTP_URL="$MUSICBRAINZ_BASE_FTP_URL"
+BASE_FTP_URL=''
+MIRROR_URL="$MUSICBRAINZ_MIRROR_URL"
 TARGET=''
 WGET_CMD=(wget)
 
@@ -21,14 +22,16 @@ Targets:
   search        Fetch latest search indexes only.
 
 Options:
-  --base-ftp-url <url>          Specify URL to MetaBrainz/MusicBrainz FTP directory.
-                                (Default: '$BASE_FTP_URL')
+  --base-ftp-url <url>          Specify URL of a MetaBrainz/MusicBrainz FTP mirror server.
+                                (Note: this option is deprecated and will be removed in a future release)
+  --mirror-url <url>            Specify URL of a MetaBrainz/MusicBrainz mirror server.
+                                (Default: '$MIRROR_URL')
   --wget-options <wget options> Specify additional options to be passed to wget,
                                 these should be separated with whitespace,
                                 the list should be a single argument
                                 (escape whitespaces if needed).
 
-  -h, --help                    Print this help message.
+  -h, --help                    Print this help message and exit.
 EOH
 )
 
@@ -48,10 +51,20 @@ do
 			;;
 		--base-ftp-url )
 			shift
+			echo >&2 "Warning: --base-ftp-url is deprecated and will be removed in a future release"
 			BASE_FTP_URL="$1"
 			if ! [[ $BASE_FTP_URL =~ ^ftp:// ]]
 			then
 				BASE_FTP_URL="ftp://$BASE_FTP_URL"
+			fi
+			;;
+		--mirror-url )
+			shift
+			MIRROR_URL="$1"
+			if ! [[ $MIRROR_URL =~ "^(ftp|https?)://" ]]
+			then
+				echo >&2 "$SCRIPT_NAME: --mirror-url must begin with ftp://, http:// or https://"
+				exit 64 # EX_USAGE
 			fi
 			;;
 		--wget-options )
@@ -92,10 +105,10 @@ then
 	echo "$(date): Fetching search indexes dump..."
 	cd "$SEARCH_DUMP_DIR" && find . -delete && cd -
 	"${WGET_CMD[@]}" -nd -nH -P "$SEARCH_DUMP_DIR" \
-		"$BASE_FTP_URL/data/search-indexes/LATEST"
+		"${BASE_FTP_URL:-$MIRROR_URL}/data/search-indexes/LATEST"
 	DUMP_TIMESTAMP=$(cat /media/searchdump/LATEST)
 	"${WGET_CMD[@]}" -nd -nH -r -P "$SEARCH_DUMP_DIR" \
-		"$BASE_FTP_URL/data/search-indexes/$DUMP_TIMESTAMP/"
+		"${BASE_FTP_URL:-$MIRROR_URL}/data/search-indexes/$DUMP_TIMESTAMP/"
 	cd "$SEARCH_DUMP_DIR" && md5sum -c MD5SUMS && cd -
 	if [[ $TARGET == search ]]
 	then
@@ -139,7 +152,7 @@ then
 
 	SEARCH_DUMP_DAY="${DUMP_TIMESTAMP/-*}"
 	"${WGET_CMD[@]}" --spider --no-remove-listing -P "$DB_DUMP_DIR" \
-		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR"
+		"${BASE_FTP_URL:-$MIRROR_URL}/$DB_DUMP_REMOTE_DIR"
 	DUMP_TIMESTAMP=$(
 		grep -E "\\s${SEARCH_DUMP_DAY}-\\d*" "$DB_DUMP_DIR/.listing" \
 			| sed -e 's/\s*$//' -e 's/.*\s//'
@@ -151,7 +164,7 @@ then
 	# Just find latest database dump
 
 	"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
-		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
+		"${BASE_FTP_URL:-$MIRROR_URL}/$DB_DUMP_REMOTE_DIR/LATEST"
 	DUMP_TIMESTAMP=$(cat "$DB_DUMP_DIR/LATEST")
 fi
 
@@ -162,7 +175,7 @@ then
 	for F in MD5SUMS "${DB_DUMP_FILES[@]}"
 	do
 		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
-			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+			"${BASE_FTP_URL:-$MIRROR_URL}/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
 	done
 	cd "$DB_DUMP_DIR"
 	for F in "${DB_DUMP_FILES[@]}"
@@ -179,7 +192,7 @@ then
 	for F in "${DB_DUMP_FILES[@]}"
 	do
 		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
-			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+			"${BASE_FTP_URL:-$MIRROR_URL}/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
 	done
 fi
 

--- a/docker-compose.alt.db-only-mirror.yml
+++ b/docker-compose.alt.db-only-mirror.yml
@@ -47,7 +47,7 @@ services:
       - ./default/postgres.env
     environment:
       - MUSICBRAINZ_BASE_FTP_URL=${MUSICBRAINZ_BASE_FTP_URL:-}
-      - MUSICBRAINZ_MIRROR_URL=${MUSICBRAINZ_MIRROR_URL:-http://ftp.eu.metabrainz.org/pub/musicbrainz}
+      - MUSICBRAINZ_BASE_DOWNLOAD_URL=${MUSICBRAINZ_BASE_DOWNLOAD_URL:-http://ftp.eu.metabrainz.org/pub/musicbrainz}
       - MUSICBRAINZ_WEB_SERVER_HOST=${MUSICBRAINZ_WEB_SERVER_HOST:-localhost}
       - MUSICBRAINZ_WEB_SERVER_PORT=${MUSICBRAINZ_WEB_SERVER_PORT:-5000}
     command: load-crontab-only.sh

--- a/docker-compose.alt.db-only-mirror.yml
+++ b/docker-compose.alt.db-only-mirror.yml
@@ -46,7 +46,8 @@ services:
     env_file:
       - ./default/postgres.env
     environment:
-      - MUSICBRAINZ_BASE_FTP_URL=${MUSICBRAINZ_BASE_FTP_URL:-ftp://ftp.eu.metabrainz.org/pub/musicbrainz}
+      - MUSICBRAINZ_BASE_FTP_URL=${MUSICBRAINZ_BASE_FTP_URL:-}
+      - MUSICBRAINZ_MIRROR_URL=${MUSICBRAINZ_MIRROR_URL:-http://ftp.eu.metabrainz.org/pub/musicbrainz}
       - MUSICBRAINZ_WEB_SERVER_HOST=${MUSICBRAINZ_WEB_SERVER_HOST:-localhost}
       - MUSICBRAINZ_WEB_SERVER_PORT=${MUSICBRAINZ_WEB_SERVER_PORT:-5000}
     command: load-crontab-only.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - ./default/postgres.env
     environment:
       - MUSICBRAINZ_BASE_FTP_URL=${MUSICBRAINZ_BASE_FTP_URL:-}
-      - MUSICBRAINZ_MIRROR_URL=${MUSICBRAINZ_MIRROR_URL:-http://ftp.eu.metabrainz.org/pub/musicbrainz}
+      - MUSICBRAINZ_BASE_DOWNLOAD_URL=${MUSICBRAINZ_BASE_DOWNLOAD_URL:-http://ftp.eu.metabrainz.org/pub/musicbrainz}
       - MUSICBRAINZ_SERVER_PROCESSES=${MUSICBRAINZ_SERVER_PROCESSES:-10}
       - MUSICBRAINZ_USE_PROXY=1
       - MUSICBRAINZ_WEB_SERVER_HOST=${MUSICBRAINZ_WEB_SERVER_HOST:-localhost}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,8 @@ services:
     env_file:
       - ./default/postgres.env
     environment:
-      - MUSICBRAINZ_BASE_FTP_URL=${MUSICBRAINZ_BASE_FTP_URL:-ftp://ftp.eu.metabrainz.org/pub/musicbrainz}
+      - MUSICBRAINZ_BASE_FTP_URL=${MUSICBRAINZ_BASE_FTP_URL:-}
+      - MUSICBRAINZ_MIRROR_URL=${MUSICBRAINZ_MIRROR_URL:-http://ftp.eu.metabrainz.org/pub/musicbrainz}
       - MUSICBRAINZ_SERVER_PROCESSES=${MUSICBRAINZ_SERVER_PROCESSES:-10}
       - MUSICBRAINZ_USE_PROXY=1
       - MUSICBRAINZ_WEB_SERVER_HOST=${MUSICBRAINZ_WEB_SERVER_HOST:-localhost}


### PR DESCRIPTION
User have reported issues fetching DB dumps using FTP, and further investigation revealed that they were due to the use of IPv4-mapped IPv6 addresses. Unfortunately this issue cannot be resolved easily due to the idiosyncratic nature of the FTP protocol. This commit changes the default download protocol from FTP to HTTP, which will resolve the issue and allow us to make DB dumps available over IPv6 in future.

Note that variable names containing FTP have not been changed for backward compatibility reasons.