### PR TITLE
Update UI languages

### DIFF
--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -432,7 +432,7 @@ sub DEVELOPMENT_SERVER { $ENV{MUSICBRAINZ_DEVELOPMENT_SERVER} == 1 ? 1 : 0 }
 # are not yet properly supported, like right-to-left languages
 sub MB_LANGUAGES { shift->DEVELOPMENT_SERVER()
     ? qw( de el es-es et he fi fr it ja nl en )
-    : qw( de fr nl en )
+    : qw( de fr it nl en )
 }
 
 # Should the site fall back to browser settings when trying to set a language

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -431,7 +431,7 @@ sub DEVELOPMENT_SERVER { $ENV{MUSICBRAINZ_DEVELOPMENT_SERVER} == 1 ? 1 : 0 }
 # file is active because we might have fully translated languages which
 # are not yet properly supported, like right-to-left languages
 sub MB_LANGUAGES { shift->DEVELOPMENT_SERVER()
-    ? qw( de el es-es et he fi fr it ja nl en )
+    ? qw( de el es-es et he fi fr it ja nl sq en )
     : qw( de fr it nl en )
 }
 

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -431,7 +431,7 @@ sub DEVELOPMENT_SERVER { $ENV{MUSICBRAINZ_DEVELOPMENT_SERVER} == 1 ? 1 : 0 }
 # file is active because we might have fully translated languages which
 # are not yet properly supported, like right-to-left languages
 sub MB_LANGUAGES { shift->DEVELOPMENT_SERVER()
-    ? qw( de el es-es et fi fr it ja nl en )
+    ? qw( de el es-es et he fi fr it ja nl en )
     : qw( de fr nl en )
 }
 

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -74,6 +74,7 @@ RUN mkdir -p /usr/local/share/keyrings && \
         language-pack-et \
         language-pack-fi \
         language-pack-fr \
+        language-pack-he \
         language-pack-it \
         language-pack-ja \
         language-pack-nl \

--- a/build/musicbrainz/DBDefs.pm
+++ b/build/musicbrainz/DBDefs.pm
@@ -418,7 +418,7 @@ sub DEVELOPMENT_SERVER { $ENV{MUSICBRAINZ_DEVELOPMENT_SERVER} == 1 ? 1 : 0 }
 # file is active because we might have fully translated languages which
 # are not yet properly supported, like right-to-left languages
 sub MB_LANGUAGES { shift->DEVELOPMENT_SERVER()
-    ? qw( de el es-es et fi fr it ja nl en )
+    ? qw( de el es-es et fi fr he it ja nl en )
     : qw( de fr nl en )
 }
 

--- a/build/musicbrainz/DBDefs.pm
+++ b/build/musicbrainz/DBDefs.pm
@@ -418,7 +418,7 @@ sub DEVELOPMENT_SERVER { $ENV{MUSICBRAINZ_DEVELOPMENT_SERVER} == 1 ? 1 : 0 }
 # file is active because we might have fully translated languages which
 # are not yet properly supported, like right-to-left languages
 sub MB_LANGUAGES { shift->DEVELOPMENT_SERVER()
-    ? qw( de el es-es et fi fr he it ja nl en )
+    ? qw( de el es-es et fi fr he it ja nl sq en )
     : qw( de fr it nl en )
 }
 

--- a/build/musicbrainz/DBDefs.pm
+++ b/build/musicbrainz/DBDefs.pm
@@ -419,7 +419,7 @@ sub DEVELOPMENT_SERVER { $ENV{MUSICBRAINZ_DEVELOPMENT_SERVER} == 1 ? 1 : 0 }
 # are not yet properly supported, like right-to-left languages
 sub MB_LANGUAGES { shift->DEVELOPMENT_SERVER()
     ? qw( de el es-es et fi fr he it ja nl en )
-    : qw( de fr nl en )
+    : qw( de fr it nl en )
 }
 
 # Should the site fall back to browser settings when trying to set a language


### PR DESCRIPTION
# Update languages for MusicBrainz Web UI 

Follows the pull request metabrainz/musicbrainz-server#3019

* Add Albanian and Hebrew to the development setup.
  It requires rebuilding the image for `musicbrainz` even in development setup.
* Add Italian to the main UI languages.