### PR TITLE
Bump Node.js version to 18.17.1

### DIFF
--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sSLO --retry 5 https://github.com/jwilder/dockerize/releases/download/
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ARG NODE_VERSION=16.16.0
+ARG NODE_VERSION=18.17.1
 ARG PGP_SERVERS="keys.openpgp.org keyserver.ubuntu.com pgp.mit.edu"
 ARG POSTGRES_VERSION=12
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -56,7 +56,7 @@ RUN mkdir -p /usr/local/share/keyrings && \
     apt-get update && \
     apt-get install --no-install-recommends -qy \
         python2-minimal && \
-    curl -sSLO --retry 5 https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_${NODE_VERSION}-deb-1nodesource1_amd64.deb && \
+    curl -sSLO --retry 5 https://deb.nodesource.com/node_18.x/pool/main/n/nodejs/nodejs_${NODE_VERSION}-deb-1nodesource1_amd64.deb && \
     dpkg -i nodejs_${NODE_VERSION}-deb-1nodesource1_amd64.deb && \
     apt-get install --no-install-recommends -qy \
         cpanminus \

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -56,7 +56,7 @@ RUN git clone --depth=1 --branch $MUSICBRAINZ_SERVER_VERSION https://github.com/
 
 WORKDIR /musicbrainz-server
 
-ARG NODE_VERSION=16.16.0
+ARG NODE_VERSION=18.17.1
 ARG PGP_SERVERS="keys.openpgp.org keyserver.ubuntu.com pgp.mit.edu"
 RUN cp docker/yarn_pubkey.txt /tmp/yarn-key.asc && \
     cd /tmp && \
@@ -88,7 +88,7 @@ RUN cp docker/yarn_pubkey.txt /tmp/yarn-key.asc && \
     rm -f /tmp/yarn-key.asc /tmp/yarn-keyring.gpg && \
     echo "deb [signed-by=/usr/local/share/keyrings/dl.yarnpkg.com.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarnpkg.list && \
     apt-get update -o Dir::Etc::sourcelist="sources.list.d/yarnpkg.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
-    curl -sSLO --retry 5 https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_${NODE_VERSION}-deb-1nodesource1_amd64.deb && \
+    curl -sSLO --retry 5 https://deb.nodesource.com/node_18.x/pool/main/n/nodejs/nodejs_${NODE_VERSION}-deb-1nodesource1_amd64.deb && \
     dpkg -i nodejs_${NODE_VERSION}-deb-1nodesource1_amd64.deb && \
     apt-get purge -qy cmdtest && \
     apt-get install --no-install-recommends -qy \


### PR DESCRIPTION
This change follows MBS-13260 as Node 16.x is getting EOL soon. Using Node 18 has been tested in local development setup for a long time and in beta since yesterday.

Resolve #255: Node 16.16.0 is no longer available since two days ago (two weeks before the announced EOL date) thus breaking the build of image for `musicbrainz` service. (Node 16.20.2 is still available at the moment but probably not for a long time either.)