### PR TITLE
Explicitely set ulimits for mq to ERL_MAX_PORTS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,8 @@ services:
         max-size: "10m"
         max-file: "10"
     restart: unless-stopped
+    ulimits:
+      nofile: 65536
     volumes:
       - mqdata:/var/lib/rabbitmq
     expose:


### PR DESCRIPTION
# Problem

On Linux ERL_MAX_PORTS defaults to 65,536. But the Docker container for the service `mq` rather uses the host ulimits. When ulimits is infinite, it can make the container to take a very long time to start while using a lot of CPU for nothing. It depends on the host settings.

# Solution

This patch explicitely sets ulimits to 65,536 as recommended for `mq`.

See https://github.com/docker-library/rabbitmq/issues/545 for details.

Resolve #257