### PR TITLE
Fix building Postgres 12 image for the MB DB

### DIFF
--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -23,6 +23,10 @@ RUN apt-get update && \
         postgresql-server-dev-${POSTGRES_VERSION} \
     && rm -rf /var/lib/apt/lists/*
 
+# Compile en_US.UTF-8 locale specification
+RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
+    && locale-gen
+
 # There is no tag v0.4.2 (or 0.5.0) yet
 ARG PG_AMQP_GIT_REF="240d477d40c5e7a579b931c98eb29cef4edda164"
 # hadolint ignore=DL3003


### PR DESCRIPTION
For some reason, running the container `db` from a freshly built image (with `--no-cache`) is currently restarting in a loop with the following error:

    LOG:  invalid value for parameter "lc_messages": "en_US.utf8"
    LOG:  invalid value for parameter "lc_monetary": "en_US.utf8"
    LOG:  invalid value for parameter "lc_numeric": "en_US.utf8"
    LOG:  invalid value for parameter "lc_time": "en_US.utf8"
    FATAL:  configuration file "/var/lib/postgresql/data/postgresql.conf" contains errors

This patch makes it work again. Not sure why the locale started to be missing, it might be that the base image used to rebuild `postgres:12` image 5 days ago (or even earlier) has some changes about locales.

Resolves #260.