### PR TITLE
MBVM-93: Prune the entity cache on replication

### DIFF
--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -69,6 +69,9 @@ RUN eval "$(perl -Mlocal::lib)" \
         Term::Size::Any \
     && rm -rf /root/.cpan* /root/perl5/man/
 
+RUN install -m 0755 \
+    admin/replication/hooks/post-process.sample \
+    admin/replication/hooks/post-process
 COPY DBDefs.pm /musicbrainz-server/lib/
 COPY scripts/* /usr/local/bin/
 RUN cat /usr/local/bin/snippet.perllocallib.bashrc >> ~/.bashrc \


### PR DESCRIPTION
# Problem

In MusicBrainz Server, most entities are cached in Redis for 1h. When a replication packet is loaded, this cache is not invalidated, so one has to wait for 1h for the entity cache to self-invalidate.

# Solution MBVM-93

Prune the entity cache using the post-process hook script sample already available in MusicBrainz Server.

It affects mirror setup only.

# Work in progress

* [x] Test on a full database mirror
  *Running post-process hook* takes about 5s for each replication packet, that is, 2min each day, which seems to be reasonable for now.
