### PR TITLE
Prepare for Solr 9 upgrade

### DIFF
--- a/build/solr/scripts/load-search-indexes.sh
+++ b/build/solr/scripts/load-search-indexes.sh
@@ -3,7 +3,7 @@
 set -e -o pipefail -u
 
 DUMP_DIR=/media/searchdump
-DATA_DIR=/opt/solr/server/solr/data
+DATA_DIR=/var/solr/data/data
 OVERWRITE_FLAG=0
 
 SCRIPT_NAME=$(basename "$0")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     expose:
       - "8983"
     volumes:
-      - solrdata:/opt/solr/server/solr/data
+      - solrdata:/var/solr/data/data
       - searchdump:/media/searchdump
 
   mq:


### PR DESCRIPTION
1. In Solr 9, the SOLR_HOME directory has moved to /var/solr/data and the actual index data lives inside /var/solr/data/data.

### TODO:
1. Detail on how to delete old search indexes and import new ones. Existing search indexes produced by Solr 7 cannot be imported on Solr 9 (which only supports indexes produced by Solr 8 and 9).