### PR TITLE
Fix building db service with pg_amqp and new base image

### DIFF
--- a/build/postgres/Dockerfile
+++ b/build/postgres/Dockerfile
@@ -1,8 +1,10 @@
 ARG POSTGRES_VERSION=12
-FROM postgres:${POSTGRES_VERSION}
+ARG POSTGRES_IMAGE_VARIANT=bookworm
+ARG POSTGRES_IMAGE_TAG=${POSTGRES_VERSION}-${POSTGRES_IMAGE_VARIANT}
+FROM postgres:${POSTGRES_IMAGE_TAG}
 
 ARG POSTGRES_VERSION
-LABEL org.metabrainz.based-on-image="postgres:${POSTGRES_VERSION}"
+LABEL org.metabrainz.based-on-image="postgres:${POSTGRES_IMAGE_TAG}"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -33,6 +35,6 @@ ARG PG_AMQP_GIT_REF="240d477d40c5e7a579b931c98eb29cef4edda164"
 RUN git clone https://github.com/omniti-labs/pg_amqp.git /tmp/pg_amqp \
     && cd /tmp/pg_amqp \
     && git checkout "$PG_AMQP_GIT_REF" \
-    && make \
+    && make PG_CPPFLAGS=-Wno-error=implicit-int \
     && make install \
     && rm -R /tmp/*


### PR DESCRIPTION
The official Docker images for Postgres updated their base image to more recent versions of Debian, breaking the compilation of pg_amqp.

This patch sets image variant, to prevent further breakage, and compilation flag, to address the three following errors:

    2.857 /usr/bin/clang-16 -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Xclang -no-opaque-pointers -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -Wno-deprecated-non-prototype -O2  -I. -I./ -I/usr/include/postgresql/12/server -I/usr/include/postgresql/internal  -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2  -flto=thin -emit-llvm -c -o src/pg_amqp.bc src/pg_amqp.c
    2.989 src/pg_amqp.c:99:10: warning: 5 enumeration values not handled in switch: 'XACT_EVENT_PARALLEL_COMMIT', 'XACT_EVENT_PARALLEL_ABORT', 'XACT_EVENT_PRE_COMMIT'... [-Wswitch]
    2.989   switch(event) {
    2.989          ^~~~~
    2.989 src/pg_amqp.c:140:21: error: parameter 'broker_id' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    2.989 local_amqp_get_a_bs(broker_id) {
    2.989                     ^
    2.989 src/pg_amqp.c:152:19: error: parameter 'broker_id' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    2.989 local_amqp_get_bs(broker_id) {
    2.989                   ^
    2.990 src/pg_amqp.c:239:23: error: parameter 'broker_id' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    2.991 local_amqp_disconnect(broker_id) {
    2.991                       ^
    2.994 1 warning and 3 errors generated.
    2.997 make: *** [/usr/lib/postgresql/12/lib/pgxs/src/makefiles/../../src/Makefile.global:1076: src/pg_amqp.bc] Error 1