### PR TITLE
Document the possibility to use WSL2 on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ search and replication in docker.
 * Git
 * GNU Bash 4 (or higher) utilities, for [admin helper scripts](admin/) only
   (On macOS, use [Homebrew](https://brew.sh/).)
-* Linux or macOS
-  (Windows is not documented yet, it is recommended to use Ubuntu via VirtualBox
-  instead.)
+* Linux (on which this repository is tested) preferably,
+  macOS (slower, see below memory setup),
+  or Windows (much slower, either by running everything in Ubuntu via VirtualBox,
+  or by running Docker Desktop for Windows and the rest in Ubuntu via WSL2).
 
 If you use Docker Desktop on macOS you may need to increase the amount of memory
 available to containers from the default of 2GB:


### PR DESCRIPTION
# MBVM-53

Tested with @amCap1712 last week, it is possible to use WSL2 and Docker Desktop for Windows to run a database-only mirror.

Also mention that:
* only Linux is preferred as the only fully tested platform,
* macOS is slower,
* Windows is much slower,

based on our own experience.