### PR TITLE
Store bash history for musicbrainz development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # See https://docs.docker.com/compose/environment-variables/#the-env-file
 /.env
 
+# Bash history of musicbrainz container in development mode
+/.musicbrainz-dev.bash_history.d/
+
 # File created and managed by the script admin/create-amqp-extension
 /admin/.create-amqp-extension.sql
 

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -106,7 +106,8 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
     corepack enable
 
 WORKDIR /musicbrainz-server
-RUN git config --global --add safe.directory /musicbrainz-server
+RUN git config --global --add safe.directory /musicbrainz-server && \
+    ln -s /root/.bash_history.d/bash_history ~/.bash_history
 
 COPY DBDefs.pm /
 COPY scripts/* /usr/local/bin/

--- a/compose/musicbrainz-dev.yml
+++ b/compose/musicbrainz-dev.yml
@@ -8,6 +8,7 @@ services:
       context: build/musicbrainz-dev
     volumes:
       - ${MUSICBRAINZ_SERVER_LOCAL_ROOT:?Missing path of MusicBrainz Server working copy}:/musicbrainz-server
+      - ./.musicbrainz-dev.bash_history.d/:/root/.bash_history.d/:z
     environment:
       - MUSICBRAINZ_CATALYST_DEBUG=${MUSICBRAINZ_CATALYST_DEBUG:-0}
       - MUSICBRAINZ_DEVELOPMENT_SERVER=${MUSICBRAINZ_DEVELOPMENT_SERVER:-1}


### PR DESCRIPTION
# Problem

In development setup, when recreating the container for the service `musicbrainz`, the history of the commands run inside the container is gone, which is annoying for repeating commands.

# Solution

Bind mount the file `.bash_history` so that it is the always the same in development setup.

It doesn’t affect mirror/test setup which don’t need to run commands in the container anyway.

This implementation is mostly copied/slightly adapted from https://github.com/metabrainz/mmd-schema/pull/35.