### PR TITLE
MBS-13358 (I): Upgrade Perl version to 5.38.2 in development setup

### DIFF
--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -47,7 +47,6 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         libdb-dev \
         libexpat1-dev \
         libicu-dev \
-        liblocal-lib-perl \
         libpq-dev \
         libssl-dev \
         # Needed for XML::LibXML
@@ -67,6 +66,9 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         zlib1g-dev \
         && \
     rm -rf /var/lib/apt/lists/* && \
+    # Install local::lib (needed to persistently update Perl modules)
+    cpanm local::lib && \
+    rm -fr /root/.cpanm && \
     # Install yarn from nodejs
     corepack enable
 

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -15,6 +15,9 @@ RUN curl -sSLO --retry 5 https://github.com/jwilder/dockerize/releases/download/
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
+ARG PERL_VERSION=5.38.2
+ARG PERL_SRC_SUM=a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e
+
 ARG CPANMINUS_VERSION=1.7047
 ARG CPANMINUS_SRC_SUM=963e63c6e1a8725ff2f624e9086396ae150db51dd0a337c3781d09a994af05a5
 
@@ -66,6 +69,23 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         zlib1g-dev \
         && \
     rm -rf /var/lib/apt/lists/* && \
+    # Install perl (in a more recent version than available with apt)
+    cd /usr/src && \
+    curl -sSLO https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-$PERL_VERSION.tar.gz && \
+    echo "$PERL_SRC_SUM *perl-$PERL_VERSION.tar.gz" | sha256sum --strict --check - && \
+    tar -xzf perl-$PERL_VERSION.tar.gz && \
+    cd perl-$PERL_VERSION && \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && \
+    archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" && \
+    archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" && \
+    ./Configure \
+        -Darchname="$gnuArch" "$archFlag" \
+        -Duselargefiles -Duseshrplib -Dusethreads \
+        -Dvendorprefix=/usr/local -Dman1dir=none -Dman3dir=none \
+        -des && \
+    make -j$(nproc) && \
+    make install && \
+    rm -fr /usr/src/perl-$PERL_VERSION* && \
     # Install cpanm (needed to help with updating Perl modules)
     cd /usr/src && \
     curl -sSLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-$CPANMINUS_VERSION.tar.gz && \

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -15,6 +15,9 @@ RUN curl -sSLO --retry 5 https://github.com/jwilder/dockerize/releases/download/
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
+ARG CPANMINUS_VERSION=1.7047
+ARG CPANMINUS_SRC_SUM=963e63c6e1a8725ff2f624e9086396ae150db51dd0a337c3781d09a994af05a5
+
 COPY keyrings/* /etc/apt/keyrings/
 ARG NODE_MAJOR_VERSION=20
 ARG POSTGRES_VERSION=12
@@ -23,7 +26,6 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
     echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get install --no-install-recommends -qy \
-        cpanminus \
         bash-completion \
         build-essential \
         bzip2 \
@@ -64,6 +66,15 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         zlib1g-dev \
         && \
     rm -rf /var/lib/apt/lists/* && \
+    # Install cpanm (needed to help with updating Perl modules)
+    cd /usr/src && \
+    curl -sSLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-$CPANMINUS_VERSION.tar.gz && \
+    echo "$CPANMINUS_SRC_SUM *App-cpanminus-$CPANMINUS_VERSION.tar.gz" | sha256sum --strict --check - && \
+    tar -xzf App-cpanminus-$CPANMINUS_VERSION.tar.gz && \
+    cd App-cpanminus-$CPANMINUS_VERSION && \
+    perl bin/cpanm . && \
+    rm -fr /usr/src/App-cpanminus-$CPANMINUS_VERSION* && \
+    cd /root && \
     # Install local::lib (needed to persistently update Perl modules)
     cpanm local::lib && \
     rm -fr /root/.cpanm && \

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -65,18 +65,19 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         xz-utils \
         # Needed for XML:LibXML
         zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/* \
+        && \
+    rm -rf /var/lib/apt/lists/* && \
     # Install yarn from nodejs
-    && corepack enable
+    corepack enable
 
 WORKDIR /musicbrainz-server
 RUN git config --global --add safe.directory /musicbrainz-server
 
 COPY DBDefs.pm /
 COPY scripts/* /usr/local/bin/
-RUN cat /usr/local/bin/snippet.perllocallib.bashrc >> ~/.bashrc \
-    && rm /usr/local/bin/snippet.perllocallib.bashrc \
-    && ln -s /usr/local/bin/docker-entrypoint.sh /
+RUN cat /usr/local/bin/snippet.perllocallib.bashrc >> ~/.bashrc && \
+    rm /usr/local/bin/snippet.perllocallib.bashrc && \
+    ln -s /usr/local/bin/docker-entrypoint.sh /
 
 # Postgres user/password would be solely needed to compile tests
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests

--- a/build/musicbrainz-dev/Dockerfile
+++ b/build/musicbrainz-dev/Dockerfile
@@ -52,8 +52,6 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         # Needed for XML::LibXML
         libxml2-dev \
         make \
-        # Needed for ts
-        moreutils \
         nodejs \
         # Needed for Unicode::ICU::Collator
         pkg-config \
@@ -69,6 +67,10 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
     # Install local::lib (needed to persistently update Perl modules)
     cpanm local::lib && \
     rm -fr /root/.cpanm && \
+    # Install ts (needed to run admin background task scripts locally)
+    curl -sSL https://git.joeyh.name/index.cgi/moreutils.git/plain/ts?h=0.69 -o /usr/local/bin/ts && \
+    echo '01b67f3d81e6205f01cc0ada87039293ebc56596955225300dd69ec1257124f5 */usr/local/bin/ts' | sha256sum --strict --check - && \
+    chmod +x /usr/local/bin/ts && \
     # Install yarn from nodejs
     corepack enable
 

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -47,9 +47,10 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         xz-utils \
         # Needed for XML:LibXML
         zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/* \
+        && \
+    rm -rf /var/lib/apt/lists/* && \
     # Install yarn from nodejs
-    && corepack enable
+    corepack enable
 
 ARG MUSICBRAINZ_SERVER_VERSION=v-2024-03-11
 LABEL org.metabrainz.musicbrainz-server.version="${MUSICBRAINZ_SERVER_VERSION}"
@@ -57,9 +58,9 @@ RUN git clone --depth=1 --branch $MUSICBRAINZ_SERVER_VERSION https://github.com/
 
 WORKDIR /musicbrainz-server
 
-RUN eval "$(perl -Mlocal::lib)" \
-    && cpanm --installdeps --notest . \
-    && cpanm --notest \
+RUN eval "$(perl -Mlocal::lib)" && \
+    cpanm --installdeps --notest . && \
+    cpanm --notest \
         Catalyst::Plugin::StackTrace \
         Plack::Handler::Starlet \
         Plack::Middleware::Debug::Base \
@@ -67,16 +68,17 @@ RUN eval "$(perl -Mlocal::lib)" \
         Starlet \
         Starlet::Server \
         Term::Size::Any \
-    && rm -rf /root/.cpan* /root/perl5/man/
+        && \
+    rm -rf /root/.cpan* /root/perl5/man/
 
 RUN install -m 0755 \
     admin/replication/hooks/post-process.sample \
     admin/replication/hooks/post-process
 COPY DBDefs.pm /musicbrainz-server/lib/
 COPY scripts/* /usr/local/bin/
-RUN cat /usr/local/bin/snippet.perllocallib.bashrc >> ~/.bashrc \
-    && rm /usr/local/bin/snippet.perllocallib.bashrc \
-    && ln -s /usr/local/bin/docker-entrypoint.sh /
+RUN cat /usr/local/bin/snippet.perllocallib.bashrc >> ~/.bashrc && \
+    rm /usr/local/bin/snippet.perllocallib.bashrc && \
+    ln -s /usr/local/bin/docker-entrypoint.sh /
 
 # Postgres user/password would be solely needed to compile tests
 ARG POSTGRES_USER=doesntmatteraslongasyoudontcompiletests
@@ -101,10 +103,10 @@ ENV BASH_ENV=/noninteractive.bash_env \
     POSTGRES_USER=musicbrainz \
     POSTGRES_PASSWORD=musicbrainz
 
-RUN yarn install \
-    && yarn cache clean \
-    && eval "$(perl -Mlocal::lib)" \
-    && /musicbrainz-server/script/compile_resources.sh
+RUN yarn install && \
+    yarn cache clean && \
+    eval "$(perl -Mlocal::lib)" && \
+    /musicbrainz-server/script/compile_resources.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start.sh"]


### PR DESCRIPTION
# MBS-13358 (I)

This patch upgrades Perl version to 5.38.2 for the MusicBrainz Server in development setup only.

See the above linked ticket for the next steps until upgrading Perl for mirrors as well.

See commit messages for the details of the implementation which is adapted from the official [docker-perl](https://github.com/Perl/docker-perl/blob/r20240224.0/5.038.002-main%2Cthreaded-bookworm/Dockerfile).

See the last commit message for deployment instructions in development setup.