### PR TITLE
 MBS-13358 (III): Upgrade Perl version to 5.38.2 for mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ tables, the server will generally fall back to slower queries in their place.
 If you wish to configure the materialized tables, you can run:
 
 ```bash
-sudo docker-compose exec musicbrainz bash -c './admin/BuildMaterializedTables --database=MAINTENANCE all'
+sudo docker-compose exec musicbrainz bash -c 'carton exec -- ./admin/BuildMaterializedTables --database=MAINTENANCE all'
 ```
 
 ### Start website

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ If you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall:
 
 ## Components version
 
-* Current MB Branch: [v-2024-04-09](build/musicbrainz/Dockerfile#L54)
-* Current DB_SCHEMA_SEQUENCE: [28](build/musicbrainz/Dockerfile#L85)
+* Current MB Branch: [v-2024-04-09](build/musicbrainz/Dockerfile#L57)
+* Current DB_SCHEMA_SEQUENCE: [28](build/musicbrainz/Dockerfile#L92)
 * Postgres Version: [12](docker-compose.yml)
   (can be changed by setting the environment variable `POSTGRES_VERSION`)
 * MB Solr search server: [3.4.2](docker-compose.yml#L88)

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ If you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall:
 
 ## Components version
 
-* Current MB Branch: [v-2024-04-09](build/musicbrainz/Dockerfile#L68)
-* Current DB_SCHEMA_SEQUENCE: [28](build/musicbrainz/Dockerfile#L103)
+* Current MB Branch: [v-2024-04-09](build/musicbrainz/Dockerfile#L88)
+* Current DB_SCHEMA_SEQUENCE: [28](build/musicbrainz/Dockerfile#L123)
 * Postgres Version: [12](docker-compose.yml)
   (can be changed by setting the environment variable `POSTGRES_VERSION`)
 * MB Solr search server: [3.4.2](docker-compose.yml#L88)

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ If you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall:
 
 ## Components version
 
-* Current MB Branch: [v-2024-04-09](build/musicbrainz/Dockerfile#L57)
-* Current DB_SCHEMA_SEQUENCE: [28](build/musicbrainz/Dockerfile#L92)
+* Current MB Branch: [v-2024-04-09](build/musicbrainz/Dockerfile#L68)
+* Current DB_SCHEMA_SEQUENCE: [28](build/musicbrainz/Dockerfile#L103)
 * Postgres Version: [12](docker-compose.yml)
   (can be changed by setting the environment variable `POSTGRES_VERSION`)
 * MB Solr search server: [3.4.2](docker-compose.yml#L88)

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -15,6 +15,9 @@ RUN curl -sSLO --retry 5 https://github.com/jwilder/dockerize/releases/download/
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
+ARG PERL_VERSION=5.38.2
+ARG PERL_SRC_SUM=a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e
+
 ARG CPANMINUS_VERSION=1.7047
 ARG CPANMINUS_SRC_SUM=963e63c6e1a8725ff2f624e9086396ae150db51dd0a337c3781d09a994af05a5
 
@@ -26,6 +29,8 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
     echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get install --no-install-recommends -qy \
+        # Needed for building perl
+        build-essential \
         bzip2 \
         gettext \
         g++ \
@@ -50,6 +55,23 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         zlib1g-dev \
         && \
     rm -rf /var/lib/apt/lists/* && \
+    # Install perl (in a more recent version than available with apt)
+    cd /usr/src && \
+    curl -sSLO https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-$PERL_VERSION.tar.gz && \
+    echo "$PERL_SRC_SUM *perl-$PERL_VERSION.tar.gz" | sha256sum --strict --check - && \
+    tar -xzf perl-$PERL_VERSION.tar.gz && \
+    cd perl-$PERL_VERSION && \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && \
+    archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" && \
+    archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" && \
+    ./Configure \
+        -Darchname="$gnuArch" "$archFlag" \
+        -Duselargefiles -Duseshrplib -Dusethreads \
+        -Dvendorprefix=/usr/local -Dman1dir=none -Dman3dir=none \
+        -des && \
+    make -j$(nproc) && \
+    make install && \
+    rm -fr /usr/src/perl-$PERL_VERSION* && \
     # Install cpanm (needed to help with updating Perl modules)
     cd /usr/src && \
     curl -sSLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-$CPANMINUS_VERSION.tar.gz && \
@@ -63,7 +85,10 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
     cpanm local::lib && \
     rm -fr /root/.cpanm && \
     # Install yarn from nodejs
-    corepack enable
+    corepack enable && \
+    # Clean up perl build dependencies
+    apt-get purge --auto-remove -y \
+        build-essential
 
 ARG MUSICBRAINZ_SERVER_VERSION=v-2024-04-09
 LABEL org.metabrainz.musicbrainz-server.version="${MUSICBRAINZ_SERVER_VERSION}"

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -15,6 +15,9 @@ RUN curl -sSLO --retry 5 https://github.com/jwilder/dockerize/releases/download/
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
+ARG CPANMINUS_VERSION=1.7047
+ARG CPANMINUS_SRC_SUM=963e63c6e1a8725ff2f624e9086396ae150db51dd0a337c3781d09a994af05a5
+
 COPY keyrings/* /etc/apt/keyrings/
 ARG NODE_MAJOR_VERSION=20
 ARG POSTGRES_VERSION=12
@@ -23,7 +26,6 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
     echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get install --no-install-recommends -qy \
-        cpanminus \
         bzip2 \
         gettext \
         g++ \
@@ -48,6 +50,15 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         zlib1g-dev \
         && \
     rm -rf /var/lib/apt/lists/* && \
+    # Install cpanm (needed to help with updating Perl modules)
+    cd /usr/src && \
+    curl -sSLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-$CPANMINUS_VERSION.tar.gz && \
+    echo "$CPANMINUS_SRC_SUM *App-cpanminus-$CPANMINUS_VERSION.tar.gz" | sha256sum --strict --check - && \
+    tar -xzf App-cpanminus-$CPANMINUS_VERSION.tar.gz && \
+    cd App-cpanminus-$CPANMINUS_VERSION && \
+    perl bin/cpanm . && \
+    rm -fr /usr/src/App-cpanminus-$CPANMINUS_VERSION* && \
+    cd /root && \
     # Install local::lib (needed to persistently update Perl modules)
     cpanm local::lib && \
     rm -fr /root/.cpanm && \

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -97,7 +97,8 @@ RUN git clone --depth=1 --branch $MUSICBRAINZ_SERVER_VERSION https://github.com/
 WORKDIR /musicbrainz-server
 
 RUN eval "$(perl -Mlocal::lib)" && \
-    cpanm --installdeps --notest . && \
+    cpanm Carton && \
+    carton install --deployment && \
     cpanm --notest \
         Catalyst::Plugin::StackTrace \
         Plack::Handler::Starlet \
@@ -138,13 +139,14 @@ ENV BASH_ENV=/noninteractive.bash_env \
     MUSICBRAINZ_WEB_SERVER_PORT=5000 \
     # Needed for yarn to install production dependencies only
     NODE_ENV=production \
+    PERL_CARTON_CPANFILE=/musicbrainz-server/cpanfile \
     POSTGRES_USER=musicbrainz \
     POSTGRES_PASSWORD=musicbrainz
 
 RUN yarn install && \
     yarn cache clean && \
     eval "$(perl -Mlocal::lib)" && \
-    /musicbrainz-server/script/compile_resources.sh
+    carton exec -- /musicbrainz-server/script/compile_resources.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start.sh"]

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -32,7 +32,6 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         libdb-dev \
         libexpat1-dev \
         libicu-dev \
-        liblocal-lib-perl \
         libpq-dev \
         libssl-dev \
         # Needed for XML::LibXML
@@ -49,6 +48,9 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
         zlib1g-dev \
         && \
     rm -rf /var/lib/apt/lists/* && \
+    # Install local::lib (needed to persistently update Perl modules)
+    cpanm local::lib && \
+    rm -fr /root/.cpanm && \
     # Install yarn from nodejs
     corepack enable
 

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -100,8 +100,8 @@ mkdir -p $TMP_DIR
 cd /media/dbdump
 
 INITDB_OPTIONS='--echo --import'
-if ! /musicbrainz-server/script/database_exists MAINTENANCE; then
+if ! carton exec -- /musicbrainz-server/script/database_exists MAINTENANCE; then
     INITDB_OPTIONS="--createdb $INITDB_OPTIONS"
 fi
 # shellcheck disable=SC2086
-/musicbrainz-server/admin/InitDb.pl $INITDB_OPTIONS -- --skip-editor --tmp-dir $TMP_DIR "${DUMP_FILES[@]}"
+carton exec -- /musicbrainz-server/admin/InitDb.pl $INITDB_OPTIONS -- --skip-editor --tmp-dir $TMP_DIR "${DUMP_FILES[@]}"

--- a/build/musicbrainz/scripts/indexer-triggers.sh
+++ b/build/musicbrainz/scripts/indexer-triggers.sh
@@ -18,12 +18,12 @@ cd /musicbrainz-server
 
 case "$2" in
   create)
-    admin/psql < "$INDEXER_SQL_DIR/CreateFunctions.sql"
-    admin/psql < "$INDEXER_SQL_DIR/CreateTriggers.sql"
+    carton exec -- admin/psql < "$INDEXER_SQL_DIR/CreateFunctions.sql"
+    carton exec -- admin/psql < "$INDEXER_SQL_DIR/CreateTriggers.sql"
     ;;
   drop  )
-    admin/psql < "$INDEXER_SQL_DIR/DropTriggers.sql"
-    admin/psql < "$INDEXER_SQL_DIR/DropFunctions.sql"
+    carton exec -- admin/psql < "$INDEXER_SQL_DIR/DropTriggers.sql"
+    carton exec -- admin/psql < "$INDEXER_SQL_DIR/DropFunctions.sql"
     rm -frv "$INDEXER_SQL_DIR"
     ;;
   *    )

--- a/build/musicbrainz/scripts/replication.sh
+++ b/build/musicbrainz/scripts/replication.sh
@@ -3,4 +3,4 @@
 set -e
 
 dockerize -wait "tcp://${MUSICBRAINZ_POSTGRES_SERVER}:5432" -timeout 60s sleep 0
-exec /musicbrainz-server/admin/cron/mirror.sh
+exec carton exec -- /musicbrainz-server/admin/cron/mirror.sh

--- a/build/musicbrainz/scripts/start.sh
+++ b/build/musicbrainz/scripts/start.sh
@@ -6,10 +6,10 @@ if ! grep -q -s \
   "//${MUSICBRAINZ_WEB_SERVER_HOST}:${MUSICBRAINZ_WEB_SERVER_PORT}" \
   /musicbrainz-server/root/static/build/runtime.js.map
 then
-  /musicbrainz-server/script/compile_resources.sh
+  carton exec -- /musicbrainz-server/script/compile_resources.sh
 fi
 
-dockerize -wait "tcp://${MUSICBRAINZ_POSTGRES_SERVER}:5432" -timeout 60s -wait "tcp://${MUSICBRAINZ_RABBITMQ_SERVER}:5672" -timeout 60s -wait "tcp://${MUSICBRAINZ_REDIS_SERVER}:6379" -timeout 60s start_mb_renderer.pl
+dockerize -wait "tcp://${MUSICBRAINZ_POSTGRES_SERVER}:5432" -timeout 60s -wait "tcp://${MUSICBRAINZ_RABBITMQ_SERVER}:5672" -timeout 60s -wait "tcp://${MUSICBRAINZ_REDIS_SERVER}:6379" -timeout 60s carton exec -- start_mb_renderer.pl
 
 if [ -f /crons.conf -a -s /crons.conf ]
 then
@@ -17,4 +17,4 @@ then
   cron -f &
 fi
 
-start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --max-workers ${MUSICBRAINZ_SERVER_PROCESSES} --pid fcgi.pid
+carton exec -- start_server --port=5000 -- plackup -I lib -s Starlet -E deployment --max-workers ${MUSICBRAINZ_SERVER_PROCESSES} --pid fcgi.pid

--- a/build/musicbrainz/scripts/upgrade-db-schema.sh
+++ b/build/musicbrainz/scripts/upgrade-db-schema.sh
@@ -4,4 +4,4 @@ set -e -u
 
 export MUSICBRAINZ_DB_SCHEMA_SEQUENCE=27
 
-dockerize -wait "tcp://${MUSICBRAINZ_POSTGRES_SERVER}:5432" -timeout 60s ./upgrade.sh
+dockerize -wait "tcp://${MUSICBRAINZ_POSTGRES_SERVER}:5432" -timeout 60s carton exec -- ./upgrade.sh


### PR DESCRIPTION
# MBS-13358 (III)

This patch upgrades Perl version to 5.38.2 for the MusicBrainz Server for mirrors.

See commit messages for the details of the implementation which is adapted from the official [docker-perl](https://github.com/Perl/docker-perl/blob/r20240224.0/5.038.002-main%2Cthreaded-bookworm/Dockerfile).

This is the third and last step to implement the above linked ticket.

This pull request is targeting the branch `schema-change-2024-q2` in order to avoid messing up new installations until the schema change is released, and to allow for potential hotfixes to the current release in the meantime if needed.

## Additional changes

Install the Perl module dependencies of MusicBrainz Server using Carton, as in musicbrainz-* Docker images. It prevents breaking the build when a new version of a dependency is released with some incompatibility.