### PR TITLE
Upgrade Server to v-2024-05-13-schema-change

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ If you use [UFW](https://help.ubuntu.com/community/UFW) to manage your firewall:
 
 ## Components version
 
-* Current MB Branch: [v-2024-04-09](build/musicbrainz/Dockerfile#L88)
-* Current DB_SCHEMA_SEQUENCE: [28](build/musicbrainz/Dockerfile#L123)
+* Current MB Branch: [v-2024-05-13-schema-change](build/musicbrainz/Dockerfile#L88)
+* Current DB_SCHEMA_SEQUENCE: [29](build/musicbrainz/Dockerfile#L125)
 * Postgres Version: [16](docker-compose.yml)
   (can be changed by setting the environment variable `POSTGRES_VERSION`)
 * MB Solr search server: [3.4.2](docker-compose.yml#L88)

--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -122,7 +122,7 @@ MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
 # replication_control.current_schema_sequence.
 # This is required, there is no default in order to prevent it changing without
 # manual intervention.
-sub DB_SCHEMA_SEQUENCE { 28 }
+sub DB_SCHEMA_SEQUENCE { 29 }
 
 # What type of server is this?
 # * RT_MASTER - This is a master replication server.  Changes are allowed, and

--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -90,7 +90,7 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesourc
     apt-get purge --auto-remove -y \
         build-essential
 
-ARG MUSICBRAINZ_SERVER_VERSION=v-2024-04-09
+ARG MUSICBRAINZ_SERVER_VERSION=v-2024-05-13-schema-change
 LABEL org.metabrainz.musicbrainz-server.version="${MUSICBRAINZ_SERVER_VERSION}"
 RUN git clone --depth=1 --branch $MUSICBRAINZ_SERVER_VERSION https://github.com/metabrainz/musicbrainz-server.git musicbrainz-server
 
@@ -126,7 +126,7 @@ ARG POSTGRES_PASSWORD=doesntmatteraslongasyoudontcompiletests
 ENV BASH_ENV=/noninteractive.bash_env \
     MUSICBRAINZ_BASE_DOWNLOAD_URL=https://data.metabrainz.org/pub/musicbrainz \
     MUSICBRAINZ_CATALYST_DEBUG=0 \
-    MUSICBRAINZ_DB_SCHEMA_SEQUENCE=28 \
+    MUSICBRAINZ_DB_SCHEMA_SEQUENCE=29 \
     MUSICBRAINZ_DEVELOPMENT_SERVER=0 \
     MUSICBRAINZ_POSTGRES_SERVER=db \
     MUSICBRAINZ_POSTGRES_READONLY_SERVER=db \

--- a/build/musicbrainz/scripts/upgrade-db-schema.sh
+++ b/build/musicbrainz/scripts/upgrade-db-schema.sh
@@ -2,6 +2,6 @@
 
 set -e -u
 
-export MUSICBRAINZ_DB_SCHEMA_SEQUENCE=27
+export MUSICBRAINZ_DB_SCHEMA_SEQUENCE=28
 
 dockerize -wait "tcp://${MUSICBRAINZ_POSTGRES_SERVER}:5432" -timeout 60s carton exec -- ./upgrade.sh


### PR DESCRIPTION
It brings MusicBrainz database schema 29 and requires manual upgrade.

See release notes for detailed upgrade steps.

## Checklist

* [x] Merge the parent pull request #277
* [x] Double-check that destination branch is `schema-change-2024-q2` and rebase if needed