### PR TITLE
Set up SIR development via Docker Compose environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,9 @@ Simply restart the container when checking out a new branch.
 
 This is very similar to the above but for Search Index Rebuilder (SIR):
 
-1. Set the variable `SIR_LOCAL_ROOT` in the `.env` file
+1. Optionally set the variable `SIR_LOCAL_ROOT` in the `.env` file
+   (Default: `../sir` assuming that `musicbrainz-docker` and `sir`
+   have been cloned under the same parent directory)
 2. Run `admin/configure add sir-dev`
 3. Run `sudo docker-compose up -d`
 

--- a/README.md
+++ b/README.md
@@ -581,7 +581,9 @@ Simply restart the container when checking out a new branch.
 This is very similar to the above but for Search Index Rebuilder (SIR):
 
 1. Optionally set the following variables in the `.env` file:
-   - `SIR_LOCAL_ROOT`
+   - `SIR_DEV_CONFIG_PATH`
+     (Default: `./default/config.ini` replacing `SIR_CONFIG_PATH`)
+   - `SIR_DEV_LOCAL_ROOT`
      (Default: `../sir` assuming that `musicbrainz-docker` and `sir`
      have been cloned under the same parent directory)
    - `SIR_DEV_PYTHON_VERSION`

--- a/README.md
+++ b/README.md
@@ -580,11 +580,19 @@ Simply restart the container when checking out a new branch.
 
 This is very similar to the above but for Search Index Rebuilder (SIR):
 
-1. Optionally set the variable `SIR_LOCAL_ROOT` in the `.env` file
-   (Default: `../sir` assuming that `musicbrainz-docker` and `sir`
-   have been cloned under the same parent directory)
+1. Optionally set the following variables in the `.env` file:
+   - `SIR_LOCAL_ROOT`
+     (Default: `../sir` assuming that `musicbrainz-docker` and `sir`
+     have been cloned under the same parent directory)
+   - `SIR_DEV_PYTHON_VERSION`
+     (Default: `2.7` matching `metabrainz/python` image tag)
+   - `SIR_DEV_BASE_IMAGE_DATE`
+     (Default: `20220421` matching `metabrainz/python` image tag)
+   - `SIR_DEV_VERSION`
+     (Default: `py27-stage1` which is informative only)
 2. Run `admin/configure add sir-dev`
-3. Run `sudo docker-compose up -d`
+3. Run `sudo docker-compose build indexer`
+4. Run `sudo docker-compose up -d`
 
 Notes:
 

--- a/build/sir-dev/Dockerfile
+++ b/build/sir-dev/Dockerfile
@@ -52,6 +52,11 @@ RUN echo Requirements will be installed at run time from entrypoint. \
 
 WORKDIR /code
 
+ENV MUSICBRAINZ_RABBITMQ_SERVER=mq \
+    MUSICBRAINZ_POSTGRES_SERVER=db \
+    MUSICBRAINZ_POSTGRES_READONLY_SERVER=db \
+    MUSICBRAINZ_SEARCH_SERVER=search:8983/solr
+
 ENV POSTGRES_USER=musicbrainz
 ENV POSTGRES_PASSWORD=musicbrainz
 ENV PYTHONUSERBASE="/code/venv-musicbrainz-docker"

--- a/compose/sir-dev.yml
+++ b/compose/sir-dev.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - ./default/postgres.env
     volumes:
-      - ${SIR_LOCAL_ROOT:?Missing path of sir working copy}:/code
+      - ${SIR_LOCAL_ROOT:-../sir}:/code
       - ${SIR_CONFIG_PATH:-./default/indexer.ini}:/code/config.ini
     depends_on:
       - db

--- a/compose/sir-dev.yml
+++ b/compose/sir-dev.yml
@@ -4,7 +4,12 @@ version: '3.1'
 
 services:
   indexer:
-    build: build/sir-dev
+    build:
+      context: build/sir-dev
+      args:
+        - PYTHON_VERSION=${SIR_DEV_PYTHON_VERSION:-2.7}
+        - BASE_IMAGE_DATE=${SIR_DEV_BASE_IMAGE_DATE:-20220421}
+        - SIR_VERSION=${SIR_DEV_VERSION:-py27-stage1}
     env_file:
       - ./default/postgres.env
     volumes:

--- a/compose/sir-dev.yml
+++ b/compose/sir-dev.yml
@@ -13,8 +13,8 @@ services:
     env_file:
       - ./default/postgres.env
     volumes:
-      - ${SIR_LOCAL_ROOT:-../sir}:/code
-      - ${SIR_CONFIG_PATH:-./default/indexer.ini}:/code/config.ini
+      - ${SIR_DEV_LOCAL_ROOT:-../sir}:/code
+      - ${SIR_DEV_CONFIG_PATH:-./default/indexer.ini}:/code/config.ini
     depends_on:
       - db
       - mq

--- a/default/indexer.ini
+++ b/default/indexer.ini
@@ -25,4 +25,4 @@ vhost = /search-index-rebuilder
 prefetch_count = 350
 
 [sentry]
-dsn = ""
+dsn =


### PR DESCRIPTION
## Problem

Previously, running a different version of SIR in development setup was requiring either to modify the `Dockerfile` or to add a local compose file setting build arguments, making it tedious to switch from one version to another.

## Solution

- Prefix all variables for SIR development setup with `SIR_DEV_` so that they don’t need to be unset when switching from SIR local clone to SIR current release.
- Add Docker Compose environment variables to set SIR build arguments in development setup.

### Additionally

Fix setting environment variables in SIR development container for use with its entry point.
Set `../sir` as the default value for the path to the Git clone of `sir` repository.

## Tests

In a setup installed for local development of MusicBrainz Server.

1. Tested checking out the tag `v3.0.1` in a clone of `sir` repository created under the same parent directory as `musicbrainz-docker` clone, and then following the instructions.

   Inspected `indexer` container for variables, followed its logs until _Runit started_, and reindexed `instrument` successfully.

2. Tested checking out the branch `2to3` (currently at commit `b2ed6dbc3b983c92f46adf8fd80e56abecba7a4a`) in the same clone of `sir`, setting the below variables in the file `.env`, and then following the instructions.

   ```env
   SIR_DEV_PYTHON_VERSION=3.11
   SIR_DEV_BASE_IMAGE_DATE=20231006
   SIR_DEV_VERSION=2py3-gb2ed6db
   ```

   Inspected `indexer` container for variables, followed its logs until _Runit started_, and reindexed `instrument` with _Unsupported scheme ''_ error which has to be investigated, more likely in `sir` repository than here.