### PR TITLE
Fetch the event-art-archive dump

### DIFF
--- a/build/musicbrainz-dev/scripts/createdb.sh
+++ b/build/musicbrainz-dev/scripts/createdb.sh
@@ -63,6 +63,7 @@ case "$IMPORT" in
             mbdump.tar.bz2
             mbdump-cdstubs.tar.bz2
             mbdump-cover-art-archive.tar.bz2
+            mbdump-event-art-archive.tar.bz2
             mbdump-derived.tar.bz2
             mbdump-stats.tar.bz2
             mbdump-wikidocs.tar.bz2

--- a/build/musicbrainz-dev/scripts/fetch-dump.sh
+++ b/build/musicbrainz-dev/scripts/fetch-dump.sh
@@ -216,6 +216,7 @@ case "$TARGET" in
 			mbdump.tar.bz2
 			mbdump-cdstubs.tar.bz2
 			mbdump-cover-art-archive.tar.bz2
+			mbdump-event-art-archive.tar.bz2
 			mbdump-derived.tar.bz2
 			mbdump-stats.tar.bz2
 			mbdump-wikidocs.tar.bz2

--- a/build/musicbrainz/scripts/createdb.sh
+++ b/build/musicbrainz/scripts/createdb.sh
@@ -63,6 +63,7 @@ case "$IMPORT" in
             mbdump.tar.bz2
             mbdump-cdstubs.tar.bz2
             mbdump-cover-art-archive.tar.bz2
+            mbdump-event-art-archive.tar.bz2
             mbdump-derived.tar.bz2
             mbdump-stats.tar.bz2
             mbdump-wikidocs.tar.bz2

--- a/build/musicbrainz/scripts/fetch-dump.sh
+++ b/build/musicbrainz/scripts/fetch-dump.sh
@@ -216,6 +216,7 @@ case "$TARGET" in
 			mbdump.tar.bz2
 			mbdump-cdstubs.tar.bz2
 			mbdump-cover-art-archive.tar.bz2
+			mbdump-event-art-archive.tar.bz2
 			mbdump-derived.tar.bz2
 			mbdump-stats.tar.bz2
 			mbdump-wikidocs.tar.bz2


### PR DESCRIPTION
We already fetch/import the cover-art-archive dump by default, so it makes sense to me to do the same for event-art-archive. This also prevents warning messages about rows from the EAA tables being missing during replication.