### PR TITLE
Fix instructions to recreate a mirror with search

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,10 +676,11 @@ If you need to recreate the database with indexed search,
 ```bash
 admin/configure rm replication-cron # if replication is enabled
 docker compose stop
-docker compose run --rm musicbrainz fetch-dump.sh both
+docker compose run --rm musicbrainz fetch-dump.sh indexed
 admin/purge-message-queues
-docker compose run --rm search fetch-backup-archives
-docker compose run --rm search load-backup-archives
+docker compose up -d search
+docker compose exec search fetch-backup-archives
+docker compose exec search load-backup-archives
 docker compose run --rm musicbrainz recreatedb.sh
 docker compose up -d
 admin/setup-amqp-triggers install
@@ -687,14 +688,16 @@ admin/configure add replication-cron
 docker compose up -d
 ```
 
- you will need to enter the
-postgres password set in [postgres.env](default/postgres.env):
+ you will need to enter the postgres password set in
+[postgres.env](default/postgres.env):
 
 * `docker compose run --rm musicbrainz recreatedb.sh`
 
-or to fetch new data dumps before recreating the database:
+Once you are satisfied with the search results, you can drop the fetched archive files:
 
-* `docker compose run --rm musicbrainz recreatedb.sh -fetch`
+```bash
+sudo docker-compose exec search remove-backup-archives
+```
 
 ## Update
 

--- a/README.md
+++ b/README.md
@@ -671,7 +671,7 @@ or to fetch new data dumps before recreating the database:
 
 ### Recreate database with indexed search
 
-If you need to recreate the database with indexed search,
+If you need to recreate the database with indexed search:
 
 ```bash
 admin/configure rm replication-cron # if replication is enabled
@@ -681,23 +681,24 @@ admin/purge-message-queues
 docker compose up -d search
 docker compose exec search fetch-backup-archives
 docker compose exec search load-backup-archives
+# See the note no. 1 below
 docker compose run --rm musicbrainz recreatedb.sh
 docker compose up -d
 admin/setup-amqp-triggers install
 admin/configure add replication-cron
 docker compose up -d
+# See the note no. 2 below
 ```
 
- you will need to enter the postgres password set in
-[postgres.env](default/postgres.env):
+Notes:
+1. You will need to enter the postgres password set in
+   [postgres.env](default/postgres.env) when running the command
+   `recreatedb.sh`
+2. Once you are satisfied with the search results, you can drop the fetched archive files:
 
-* `docker compose run --rm musicbrainz recreatedb.sh`
-
-Once you are satisfied with the search results, you can drop the fetched archive files:
-
-```bash
-sudo docker-compose exec search remove-backup-archives
-```
+   ```bash
+   sudo docker-compose exec search remove-backup-archives
+   ```
 
 ## Update
 


### PR DESCRIPTION
It amends the pull request https://github.com/metabrainz/musicbrainz-docker/pull/304 and more particularly the commit https://github.com/metabrainz/musicbrainz-docker/commit/3bdcaac7415daadbffbd5fe46964e2015fe0d0b1 about the **instructions to recreate the database with (Solr) indexed search**, thus addressing the issue https://github.com/metabrainz/musicbrainz-docker/issues/313 reported by @PeterCodar.

Note that it assumes that the mirror owner previously followed the [upgrade instructions for the release `v-2025-05-29.0-solr9`](https://github.com/metabrainz/musicbrainz-docker/releases/tag/v-2025-05-29.0-solr9).