### PR TITLE
Fix instructions to load backup archives again

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,8 @@ If you need to recreate the database with indexed search:
 ```bash
 admin/configure rm replication-cron # if replication is enabled
 docker compose stop
+docker compose rm search
+docker volume rm 'musicbrainz-docker_solrdata' # assuming the default
 docker compose run --rm musicbrainz fetch-dump.sh indexed
 admin/purge-message-queues
 docker compose up -d search


### PR DESCRIPTION
# Problem

When loading (SolrCloud) backup archives again, Solr does remove the previously restored content of each collection excepted the collection `recording` which happens to have more than one shard and more than 50G.

This behavior is currently neither documented nor reported as a bug. It has to be reproduced and reported with the latest version of Solr.

# Solution

In the meantime, this patch provides a workaround which consists in removing the volume containing Solr data beforehand. That should prevent filling up the device storing Docker volumes as in the issue #316.

## Reference

https://solr.apache.org/guide/solr/9_7/deployment-guide/collection-management.html#restore