### PR TITLE
Jdlh docs clarify db port readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,8 @@ admin/configure add publishing-all-ports
 docker compose up -d
 ```
 
-If you are running a database only mirror, run this instead:
+To publish the port of the service `db` only (additionally to `musicbrainz`) on the host, or if 
+you are running a database only mirror, run this instead:
 
 ```bash
 admin/configure add publishing-db-port

--- a/README.md
+++ b/README.md
@@ -454,6 +454,21 @@ The helper script [`admin/configure`](admin/configure) is able to:
 Try `admin/configure help` for more information.
 
 #### Publish ports of all services
+To publish ports of services `db`, `mq`, `redis` and `search`
+(additionally to `musicbrainz`) on the host, simply run:
+
+```bash
+admin/configure add publishing-all-ports
+docker compose up -d
+```
+
+To publish the port of just the service `db` (additionally to `musicbrainz`) on the host, or if 
+you are running a database only mirror, run this instead:
+
+```bash
+admin/configure add publishing-db-port
+docker compose up -d
+```
 
 :warning: The service `search` is currently running Solr 7 in
 standalone mode which is vulnerable to privilege escalation.
@@ -464,22 +479,6 @@ In general, Solr is strongly recommended to be accessible to your own clients on
 See [Solr Security](https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity) for details.
 Similarly, other services have not been configured to be safely publicly accessible either.
 Take this warning in consideration when publishing their ports.
-
-To publish ports of services `db`, `mq`, `redis` and `search`
-(additionally to `musicbrainz`) on the host, simply run:
-
-```bash
-admin/configure add publishing-all-ports
-docker compose up -d
-```
-
-To publish the port of the service `db` only (additionally to `musicbrainz`) on the host, or if 
-you are running a database only mirror, run this instead:
-
-```bash
-admin/configure add publishing-db-port
-docker compose up -d
-```
 
 #### Modify memory settings
 


### PR DESCRIPTION
Add a sentence to the section about port publishing in the README.md. Make it clearer that this applies to people who want a database port, not just to people running a database-only server.

Also move the Solr vulnerability warning to the end of the section. When it is positioned at the beginning, it distracts attention from the main point of the section, which is how to publish ports.

This addresses confusion I had when following these instructions to set up a MusicBrainz mirror server. See discussion thread at https://community.metabrainz.org/t/how-to-run-sql-queries-on-musicbrainz-docker-conveniently/807221?u=jim_delahunt . 