### PR TITLE
Add "Connection errors during reindex" to TROUBLESHOOTING.md

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -10,6 +10,7 @@
 - [ImportError: No module named](#importerror-no-module-named)
 - [Unknown error executing apt-key](#unknown-error-executing-apt-key)
 - [amqp.exceptions.AccessRefused](#amqpexceptionsaccessrefused)
+- [Connection errors during reindex](#connection-errors-during-reindex)
 
 <!-- tocstop -->
 
@@ -164,3 +165,59 @@ docker compose logs -t mq | grep 'Creating user .sir.'
 
 If it doesn’t mention _creating user sir_, try recreating `mq` again.
 
+## Connection errors during reindex
+
+When running **reindex** on the **indexer** service, if the command output emits errors like:
+
+* `pysolr.SolrError: Failed to connect to server`
+* `ConnectionRefusedError: [Errno 111] Connection refused.`
+* `ConnectionResetError: [Errno 104] Connection reset by peer`
+* `pysolr.SolrError: Failed to connect to server at http://search:8983/solr/recording/update/`
+* `('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))`
+* `pysolr.SolrError: Solr responded with an error (HTTP 404): [Reason: None]`
+* `(psycopg2.OperationalError) server closed the connection unexpectedly`
+* `pysolr.SolrError: Failed to connect to server at http://search:8983/solr/recording/update/`
+* `Failed to resolve 'search' ([Errno -2] Name or service not known)")`
+
+These might all be symptoms of the **search** service having insufficient memory, causing the Solr process to end abruptly then restart.
+
+For further evidence, look at the docker logs of the **search** service.  When the Solr process stops abruptly, you might see diagnostics like:
+```text
+... [elided] ...
+2025-11-25 04:00:25.510 INFO  (searcherExecutor-83-thread-2-processing-172.18.0.6:8983_solr recording_shard4_replica_n1 recording shard4 core_node3) [c:recording s:shard4 r:core_node3 x:recording_shard4_replica_n1 t:] o.a.s.c.SolrCore Registered new searcher autowarm time: 0 ms
+2025-11-25 04:00:26.528 INFO  (searcherExecutor-72-thread-2-processing-172.18.0.6:8983_solr recording_shard3_replica_n6 recording shard3 core_node8) [c:recording s:shard3 r:core_node8 x:recording_shard3_replica_n6 t:] o.a.s.c.SolrCore Registered new searcher autowarm time: 64 ms
+Killed
+Executing /opt/solr/docker/scripts/start-musicbrainz-solrcloud
+/opt/solr/docker/scripts/start-musicbrainz-solrcloud: running /docker-entrypoint-initdb.d/10-install-musicbrainz-conf.sh
+Starting Solr
+Java 17 detected. Enabled workaround for SOLR-16463
+[0.012s][warning][pagesize] UseLargePages disabled, no large pages configured and available on the system.
+CompileCommand: exclude com/github/benmanes/caffeine/cache/BoundedLocalCache.put bool exclude = true
+WARNING: A command line option has enabled the Security Manager
+WARNING: The Security Manager is deprecated and will be removed in a future release
+2025-11-25 04:00:34.759 INFO  (main) [c: s: r: x: t:] o.e.j.s.Server jetty-10.0.22; built: 2024-06-27T16:03:51.502Z; git: 5c8471e852d377fd726ad9b1692c35ffc5febb09; jvm 17.0.15+6
+2025-11-25 04:00:35.441 WARN  (main) [c: s: r: x: t:] o.e.j.u.DeprecationWarning Using @Deprecated Class org.eclipse.jetty.servlet.listener.ELContextCleaner
+2025-11-25 04:00:35.501 INFO  (main) [c: s: r: x: t:] o.a.s.s.CoreContainerProvider Using logger factory org.apache.logging.slf4j.Log4jLoggerFactory
+2025-11-25 04:00:35.525 INFO  (main) [c: s: r: x: t:] o.a.s.s.CoreContainerProvider  ___      _       Welcome to Apache Solr™ version 9.7.0
+2025-11-25 04:00:35.526 INFO  (main) [c: s: r: x: t:] o.a.s.s.CoreContainerProvider / __| ___| |_ _   Starting in cloud mode on port 8983
+2025-11-25 04:00:35.526 INFO  (main) [c: s: r: x: t:] o.a.s.s.CoreContainerProvider \__ \/ _ \ | '_|  Install dir: /opt/solr-9.7.0
+2025-11-25 04:00:35.527 INFO  (main) [c: s: r: x: t:] o.a.s.s.CoreContainerProvider |___/\___/_|_|    Start time: 2025-11-25T04:00:35.527071965Z
+2025-11-25 04:00:35.536 INFO  (main) [c: s: r: x: t:] o.a.s.s.CoreContainerProvider Solr started with "-XX:+CrashOnOutOfMemoryError" that will crash on any OutOfMemoryError exception. The cause of the OOME will be logged in the crash file at the following path: /var/solr/logs/jvm_crash_8.log
+... [elided] ...
+```
+
+The first action to take is to provide more memory to the Solr software in the **search** service, as described in 
+["Modify memory settings" in the README](https://github.com/metabrainz/musicbrainz-docker?tab=readme-ov-file#modify-memory-settings).
+
+A second action to take is to provide more memory to the Docker compose, allowing it to devote more memory to the **search** service. 
+
+If you are using the Docker.desktop app to run the Musicbrainz-docker compose, then increase the overall Memory Limit as follows:
+- In the main Docker.desktop window, push the Settings button (the gear icon in upper-right). A Settings dialogue appears.
+- In the left pane, click on the Resources entry. The right pane shows the Resources controls.
+- Move the slider labelled, "Memory Limit" to allow more memory.
+  - As of November 2025 on macOS 14, 16 GB is necessary to run reindex entity by entity, and 22+ GB is required to completely reindex at once. 
+- Press the **Apply & restart** button in the lower-right corner of the Settings dialogue. The Docker compose restarts.
+- Close the Settings dialogue.
+
+A third action to take is to run the **reindex** operation in multiple parts. Use the `--entity-type` option multiple times to select some 
+but not all of the Cores.


### PR DESCRIPTION
Add a new section, "Connection errors during reindex". It describes the problems I had getting the reindex operation to run successfully, and the changes to memory limits which worked around the problem. 

It gives examples of the error messages arising from the problems, in the hopes of providing search engine fodder for someone else experiencing the same problem.

I described my problems, my attempts at diagnosis, and my solutions at the Metabrainz community topic [MBVM-105 **Sir reindex fails with ConnectionResetError(104, 'Connection reset by peer')) and consequences**](https://tickets.metabrainz.org/browse/MBVM-105) and at the Metabrainz community topic, [**Sir reindex fails with ConnectionResetError(104, ‘Connection reset by peer’)**](https://community.metabrainz.org/t/sir-reindex-fails-with-connectionreseterror-104-connection-reset-by-peer/813779?u=jim_delahunt).  I wrote what I wanted to read to help me solve this problem.