### PR TITLE
chore: Update dockerize to 0.10.1 and download the version for proper architecture

### DIFF
--- a/build/musicbrainz/Dockerfile
+++ b/build/musicbrainz/Dockerfile
@@ -10,10 +10,11 @@ LABEL org.metabrainz.based-on-image="metabrainz/base-image:${METABRAINZ_BASE_IMA
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG DOCKERIZE_VERSION=v0.6.1
-RUN curl -sSLO --retry 5 https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-    tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-    rm -f dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+ARG TARGETARCH
+ARG DOCKERIZE_VERSION=v0.10.1
+RUN curl -sSLO --retry 5 https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-$TARGETARCH-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xzvf dockerize-linux-$TARGETARCH-$DOCKERIZE_VERSION.tar.gz && \
+    rm -f dockerize-linux-$TARGETARCH-$DOCKERIZE_VERSION.tar.gz
 
 ARG PERL_VERSION=5.38.2
 ARG PERL_SRC_SUM=a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e


### PR DESCRIPTION
This PR upgrades dockerize to 0.9.9 which provides asssets for ARM and AMD.
It seems to be the only missing piece to have working ARM images.

Currently the upstream images are not built/pushed multi-arch, but I was able to build manually every upstream image on an ARM image :
- metabrainz/base-image:jammy-1.0.1-v0.4
- metabrainz/base-image:noble-1.0.0-v0.1
- metabrainz/consul-template-base:noble-1.0.0-v0.1-1
- metabrainz/mb-solr:4.1.0
- metabrainz/musicbrainz-docker-db:16-build0
- metabrainz/python:3.13-20250313
- rabbitmq:3.6.16
- redis:3-alpine
- sir
- solr
- musicbrainz

I don't see CI configurations in these upstream repos, so I am not sure what needs to be done for them to build and push thier ARM versions to dockerhub, but at least I can confirm they build properly and that I can start the musicbrainz container.

Open to discuss and look at other repo if I missed anything