### PR TITLE
Unset `CDPATH` when running `admin/configure` in README

### DIFF
--- a/admin/lib/common.inc.bash
+++ b/admin/lib/common.inc.bash
@@ -7,7 +7,7 @@ then
   exit 69 # EX_UNAVAILABLE
 fi
 
-MB_DOCKER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)
+MB_DOCKER_ROOT=$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)
 
 cd "$MB_DOCKER_ROOT" || {
   echo >&2 "$SCRIPT_NAME: fail to change directory to '$MB_DOCKER_ROOT'"


### PR DESCRIPTION
On systems that set the CDPATH environment variable[1], cd might print the directory to stdout:

    If cd uses a non-empty directory name from CDPATH, or if -
    is the first argument, and the directory change is
    successful, cd writes the absolute pathname of the new
    working directory to the standard output.

This causes admin/lib/common.inc.bash to erroneously set MB_DOCKER_ROOT to `$'/home/musicbrainz-docker\n/home/musicbrainz-docker', which in turn causes the following error:

    $ admin/configure with alt-db-only-mirror
    admin/lib/common.inc.bash: line 12: cd: $'/home/musicbrainz-docker\n/home/musicbrainz-docker': No such file or directory
    configure: fail to change directory to '/home/musicbrainz-docker
    /home/musicbrainz-docker'

By temporarily unsetting CDPATH (just in case the user has set it), the command succeeds in my system.

[1] https://man7.org/linux/man-pages/man1/bash.1.html