### PR TITLE
prebuild-musicbrainz: Remove second push

### DIFF
--- a/admin/repository/prebuild-musicbrainz
+++ b/admin/repository/prebuild-musicbrainz
@@ -91,17 +91,6 @@ COMPOSE_FILES='-f docker-compose.yml -f compose/musicbrainz-own-build.yml -f com
 # shellcheck disable=SC2086 # intentional word splitting of options
 $DOCKER_CMD buildx bake $COMPOSE_FILES --set musicbrainz.tags="$DEST_IMAGE_TAG" --push musicbrainz
 
-echo Tagging...
-
-# shellcheck disable=SC2086 # intentional word splitting of options
-LOCAL_IMAGE_TAG=$($DOCKER_COMPOSE_CMD $COMPOSE_FILES config --images | grep -o '[^ ]*musicbrainz$')
-
-$DOCKER_CMD tag "$LOCAL_IMAGE_TAG" "$DEST_IMAGE_TAG"
-
-echo Pushing...
-
-$DOCKER_CMD push "$DEST_IMAGE_TAG"
-
 echo Done.
 
 # vi: set et sts=2 sw=2 ts=2 :


### PR DESCRIPTION
With the `--push` added in 7af8d4fbebe91853626cd342de1015ac61a9df61, the second one is unnecessary and will clobber any existing arm image on Docker Hub.