### PR TITLE
Find bash via /usr/bin/env in upgrade-to-postgres18

### DIFF
--- a/admin/upgrade-to-postgres18
+++ b/admin/upgrade-to-postgres18
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 set -e -o pipefail -u
 

--- a/admin/upgrade-to-postgres18
+++ b/admin/upgrade-to-postgres18
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 set -e -o pipefail -u
 


### PR DESCRIPTION
Fixes issue #349 . 

Old shebang `/bin/bash` does not work on macOS 14.8, or any system where /bin/bash is not the preferred copy of bash. Instead, have the shebang find bash flexibly via `/bin/env`.