### PR TITLE
In README.md, add `-T` to `docker compose exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ docker compose up -d
 Run replication script once to catch up with latest database updates:
 
 ```bash
-bash -c 'docker compose exec musicbrainz replication.sh &' && \
+bash -c 'docker compose exec -T musicbrainz replication.sh &' && \
 docker compose exec musicbrainz /usr/bin/tail -f mirror.log
 ```
 


### PR DESCRIPTION
README.md Line 247 gives a command, 
```bash -c 'docker compose exec musicbrainz replication.sh &'```. 

On my macOS system, this fails with an error message, "cannot attach stdin to a TTY-enabled container because stdin is not a terminal". The cause is apparently that `docker compose exec` tries to allocate a pseudo-terminal (TTY) by default, but the shell session has no terminal attached.

The solution is to add the `-T` flag, which tells `docker compose exec`  not to allocate a TTY.

Thus the command which works is: 
```
bash -c 'docker compose exec -T musicbrainz replication.sh &'
```