### PR TITLE
MBS-14455 (mirror): Mention MAX_SEARCH_RESULTS

### DIFF
--- a/build/musicbrainz-dev/DBDefs.pm
+++ b/build/musicbrainz-dev/DBDefs.pm
@@ -310,6 +310,11 @@ sub CACHE_MANAGER_OPTIONS {
 # indicates that no expiration is set.
 sub ENTITY_CACHE_TTL { 3600 }
 
+# The maximum amount of results requested to search.
+# It helps with saving resources through better caching.
+# If undef, the amount of results is not limited.
+# sub MAX_SEARCH_RESULTS { undef }
+
 ################################################################################
 # Sessions (advanced)
 ################################################################################

--- a/build/musicbrainz/DBDefs.pm
+++ b/build/musicbrainz/DBDefs.pm
@@ -297,6 +297,11 @@ sub CACHE_MANAGER_OPTIONS {
 # indicates that no expiration is set.
 sub ENTITY_CACHE_TTL { 3600 }
 
+# The maximum amount of results requested to search.
+# It helps with saving resources through better caching.
+# If undef, the amount of results is not limited.
+# sub MAX_SEARCH_RESULTS { undef }
+
 ################################################################################
 # Sessions (advanced)
 ################################################################################


### PR DESCRIPTION
This new setting for MusicBrainz Server allows limiting the depth of search results to preserve service cache/performance/stability.

The plan is to set the limit to 500 results in production. It stays unlimited by default for mirrors as having no limit is one of the main reasons for setting up a mirror.

For rationale, see https://tickets.metabrainz.org/browse/MBS-14455
For implementation, see: https://github.com/metabrainz/musicbrainz-server/pull/3854

_Edit:_ Tested setting `MAX_SEARCH_RESULTS` to 500 in development setup.